### PR TITLE
Resolve ant pattern in archive directory 

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
@@ -13,7 +13,7 @@
       <col width="20%"/>
       <col width="20%"/>
       <tr>
-        <td>HTML directory to archive</td>
+        <td>HTML directory to archive (Ant pattern supported)</td>
         <td>Index page[s]</td>
         <td>Report title</td>
         <td>Keep past HTML reports</td>


### PR DESCRIPTION
Hi,

Here is a quick patch to make it possible to use ant pattern in the archive directory parameter. I'm currently using this to publish gatling (http://gatling-tool.org/) HTML reports. As the reports are stored in a distinct folder each time gatling is run (under _target/gatling/run**_), this patch make it possible to specify such pattern to find the report pages.

The code can probably be improved as I don't know Jenkins internals very well, so I had to hack around the ant pattern matching system. But I've been using it since a few days and it works pretty well.

Best regards,
Reynald
