### PR TITLE
I modified the code according to my own needs

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -211,6 +211,26 @@ public class HtmlPublisher extends Recorder {
                 
                 // Ignore blank report names caused by trailing or double commas.
                 if (report.equals("")) {continue;}
+
+                //Check if the file is up to date
+                String updated = "";
+                try{
+                    FilePath archiveFile = new FilePath(archiveDir, report);
+                    long fileTime = archiveFile.lastModified();
+                    long timeDiff = build.getBuiltOn().getClockDifference().diff;
+                    Date fileDate = new Date(fileTime + timeDiff);
+                    listener.getLogger().println("[htmlpublisher] Last modified time for " + report + ": " + fileDate + ". Time diff: " + timeDiff);
+
+                    SimpleDateFormat dateFormat=new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+                    Date buildDate = dateFormat.parse(build.getId());
+                    if(fileDate.before(buildDate)){
+                        updated = " - Not generated in this build";
+                    }
+                }catch (IOException e){
+                    e.printStackTrace();
+                }catch (ParseException e){
+                    e.printStackTrace();
+                }
                 
                 reports.add(report);
                 String tabNo = "tab" + (j + 1);
@@ -222,7 +242,7 @@ public class HtmlPublisher extends Recorder {
                 } else {
                     reportName = report;
                 }
-                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" onclick=\"updateBody('" + tabNo + "');\" value=\"" + report + "\">" + reportName + "</li>";
+                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" onclick=\"updateBody('" + tabNo + "');\" value=\"" + report + "\">" + reportName + updated + "</li>";
                 reportLines.add(tabItem);
             }
             // Add the JS to change the link as appropriate.

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -139,7 +139,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         protected abstract File dir();
     }
 
-    public class HTMLAction extends BaseHTMLAction implements ProminentProjectAction {
+    public class HTMLAction extends BaseHTMLAction /*implements ProminentProjectAction*/ {
         private final AbstractItem project;
 
         public HTMLAction(AbstractItem project, HtmlPublisherTarget actualHtmlPublisherTarget) {
@@ -152,7 +152,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
             if (this.project instanceof AbstractProject) {
                 AbstractProject abstractProject = (AbstractProject) this.project;
 
-                Run run = abstractProject.getLastSuccessfulBuild();
+                Run run = abstractProject.getLastBuild();
                 if (run != null) {
                     File javadocDir = getBuildArchiveDir(run);
 


### PR DESCRIPTION
Hi, I modified the code according to my own needs, hope it helpful to others who are using this plugin.

Change details:
1.       The Job level link of HTML report is modified to be the last build’s result, not the last successful build’s result
1. ```
    Discard the redundant link on the Job level page
   ```
2. ```
    If the html file is not generated during this build, we will be informed.         
   ```

Thanks
dfeng
