### PR TITLE
simplified "back" link

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -189,14 +189,6 @@ public class HtmlPublisher extends Recorder {
             String hudsonUrl = Hudson.getInstance().getRootUrl();
             AbstractProject job = build.getProject();
             reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").innerHTML=\"Back to " + job.getName() + "\";</script>");
-            // If the URL isn't configured in Hudson, the best we can do is attempt to go Back.
-            if (hudsonUrl == null) {
-                reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").onclick = function() { history.go(-1); return false; };</script>");
-            } else {
-                String jobUrl = hudsonUrl + job.getUrl();
-                reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").href=\"" + jobUrl + "\";</script>");
-            }
-    
             reportLines.add("<script type=\"text/javascript\">document.getElementById(\"zip_link\").href=\"*zip*/" + reportTarget.getSanitizedName() + ".zip\";</script>");
 
             try {

--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -124,7 +124,7 @@ var selectedTab = "tab1"
 
 <body onload="init('tab1');">
 
-<h1><a id="hudson_link" href="#"></a></h1>
+<h1><a id="hudson_link" href="..">Back</a></h1>
 <h2><a id="zip_link" href="#">Zip</a></h2>
 
 <ul id="tabnav">


### PR DESCRIPTION
report uses some hacky JS to generate the back link, 
but as the report is only available as a job action, ".." is far enough to get back to the job view