### PR TITLE
Add an option to allow a build to not fail if a report is not present.

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -50,16 +50,22 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     private final boolean keepAll;
 
     /**
+     * If true, will allow report to be missing and build will not fail on missing report.
+     */
+    private final boolean allowMissing;
+
+    /**
      * The name of the file which will be used as the wrapper index.
      */
     private final String wrapperName = "htmlpublisher-wrapper.html";
 
     @DataBoundConstructor
-    public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles, boolean keepAll) {
+    public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles, boolean keepAll, boolean allowMissing) {
         this.reportName = reportName;
         this.reportDir = reportDir;
         this.reportFiles = reportFiles;
         this.keepAll = keepAll;
+        this.allowMissing = allowMissing;
     }
 
     public String getReportName() {
@@ -76,6 +82,10 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
 
     public boolean getKeepAll() {
         return this.keepAll;
+    }
+
+    public boolean getAllowMissing() {
+           return this.allowMissing;
     }
 
     public String getSanitizedName() {

--- a/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
@@ -17,6 +17,7 @@
         <td>Index page[s]</td>
         <td>Report title</td>
         <td>Keep past HTML reports</td>
+        <td>Allow missing report</td>
         <td/>
       </tr>
     </table>
@@ -45,7 +46,11 @@
         <td>
           <f:checkbox field="keepAll" />
         </td>
-        
+
+        <td>
+          <f:checkbox field="allowMissing" />
+        </td>
+
         <td>
           <f:repeatableDeleteButton/>
         </td>

--- a/src/test/groovy/htmlpublisher/HtmlPublisherTest.groovy
+++ b/src/test/groovy/htmlpublisher/HtmlPublisherTest.groovy
@@ -13,7 +13,7 @@ public class HtmlPublisherTest extends HudsonTestCase {
      */
     public void testConfigRoundtrip() {
         def p = createFreeStyleProject();
-        def l = [new HtmlPublisherTarget("a", "b", "c", true), new HtmlPublisherTarget("", "", "", false)]
+        def l = [new HtmlPublisherTarget("a", "b", "c", true, false), new HtmlPublisherTarget("", "", "", false, false)]
 
         p.publishersList.add(new HtmlPublisher(l));
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));
@@ -22,7 +22,7 @@ public class HtmlPublisherTest extends HudsonTestCase {
         assertEquals(2,r.reportTargets.size())
 
         (0..1).each {
-            assertEqualBeans(l[it],r.reportTargets[it],"reportName,reportDir,reportFiles,keepAll");
+            assertEqualBeans(l[it],r.reportTargets[it],"reportName,reportDir,reportFiles,keepAll,allowMissing");
         }
     }
 


### PR DESCRIPTION
Adds a toggle to each link section to select if you wish to allow
a report to not fail if it is unable to find the source file/s.
