### PR TITLE
JENKINS-24057: Allow job level links to last instead of last successful build

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
@@ -9,45 +9,54 @@
     <table width="100%">
       <col width="20%"/>
       <col width="20%"/>
-      <col width="20%"/>
-      <col width="20%"/>
-      <col width="20%"/>
+      <col width="15%"/>
+      <col width="12%"/>
+      <col width="12%"/>
+      <col width="12%"/>
+      <col width="9%"/>
       <tr>
         <td>HTML directory to archive</td>
         <td>Index page[s]</td>
         <td>Report title</td>
         <td>Keep past HTML reports</td>
+        <td>Always link to last build on job page</td>
         <td>Allow missing report</td>
         <td/>
       </tr>
     </table>
 
-      
+
     <f:repeatable field="reportTargets">
       <table width="100%">
       <col width="20%"/>
       <col width="20%"/>
-      <col width="20%"/>
-      <col width="20%"/>
-      <col width="20%"/>
+      <col width="15%"/>
+      <col width="12%"/>
+      <col width="12%"/>
+      <col width="12%"/>
+      <col width="9%"/>
       <tr>
         <td>
           <f:textbox field="reportDir" />
         </td>
-      
+
         <td>
           <f:textbox field="reportFiles"  default="index.html"/>
         </td>
-        
+
         <td>
           <f:textbox field="reportName" default="HTML Report"/>
         </td>
-        
-        <td>
+
+        <td align="center">
           <f:checkbox field="keepAll" />
         </td>
 
-        <td>
+        <td align="center">
+          <f:checkbox field="alwaysLinkToLastBuild" />
+        </td>
+
+        <td align="center">
           <f:checkbox field="allowMissing" />
         </td>
 

--- a/src/main/resources/htmlpublisher/HtmlPublisher/help.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/help.html
@@ -1,0 +1,24 @@
+<div>
+    <p>
+        Publishes HTML reports.
+        Fill the path to the directory containing the html reports in the "HTML
+        directory to archive" field. Specify the pages to display (default
+        index.html); you can specify multiple comma-separated pages and each will
+        be a tab on the report page. Finally, give a name in the Report Title
+        field, which will be used to provide a link to the report.
+    </p>
+
+    <p>
+        By default, only the most recent HTML report will be saved, but if you'd like to be
+        able to view HTML reports for each past build, select "Keep past HTML
+        reports." If you keep past html reports then only the last successful
+        build will be linked on the job page or select "Always link to last build
+        on job page" to also link to failed builds.
+    </p>
+
+    <p>
+        If the configured html can not be found, the build will be marked as
+        "failed". If you want to make the publishing of the report optional,
+        select "Allow missing report".
+    </p>
+</div>

--- a/src/test/groovy/htmlpublisher/HtmlPublisherTest.groovy
+++ b/src/test/groovy/htmlpublisher/HtmlPublisherTest.groovy
@@ -13,7 +13,7 @@ public class HtmlPublisherTest extends HudsonTestCase {
      */
     public void testConfigRoundtrip() {
         def p = createFreeStyleProject();
-        def l = [new HtmlPublisherTarget("a", "b", "c", true, false), new HtmlPublisherTarget("", "", "", false, false)]
+        def l = [new HtmlPublisherTarget("a", "b", "c", true, true, false), new HtmlPublisherTarget("", "", "", false, false, false)]
 
         p.publishersList.add(new HtmlPublisher(l));
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));
@@ -22,7 +22,7 @@ public class HtmlPublisherTest extends HudsonTestCase {
         assertEquals(2,r.reportTargets.size())
 
         (0..1).each {
-            assertEqualBeans(l[it],r.reportTargets[it],"reportName,reportDir,reportFiles,keepAll,allowMissing");
+            assertEqualBeans(l[it],r.reportTargets[it],"reportName,reportDir,reportFiles,keepAll,alwaysLinkToLastBuild,allowMissing");
         }
     }
 


### PR DESCRIPTION
Contributes to JENKINS-24057
Possibly fixes JENKINS-11689 and JENKINS-5682

I added an option to an HTML report to always link to the latest build instead of the latest successful link. Default behaviour is like before to link to the latest successful build if the "Keep past HTML reports" is selected. 

I also added a help.html to describe the behaviour of the HTML publisher. I partly copied the Wiki description for this and added a description for the "Allow missing report" option and the new "Always link to last build job page" option. 