### PR TITLE
Select index pages using FileSet includes.

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -167,9 +167,12 @@ public class HtmlPublisher extends Recorder {
             listener.getLogger().println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
             // The index name might be a comma separated list of names or include a pattern like "*.html", so let's figure out all the pages we should index.
-            FileSet fs = Util.createFileSet(new File(archiveDir.getRemote()), resolveParametersInString(build, listener, reportTarget.getReportFiles()));
-            DirectoryScanner ds = fs.getDirectoryScanner();
-            String[] csvReports = ds.getIncludedFiles();
+            String[] csvReports = {};
+            File archiveDirFile = new File(archiveDir.getRemote());
+            if (archiveDirFile.exists()) {
+              FileSet fs = Util.createFileSet(archiveDirFile, resolveParametersInString(build, listener, reportTarget.getReportFiles()));
+              csvReports = fs.getDirectoryScanner().getIncludedFiles();
+            }
             ArrayList<String> reports = new ArrayList<String>();
             for (int j=0; j < csvReports.length; j++) {
                 String report = csvReports[j];

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -46,6 +46,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.DirectoryScanner;
+
 /**
  * Saves HTML reports for the project and publishes them.
  * 
@@ -163,8 +166,10 @@ public class HtmlPublisher extends Recorder {
             String levelString = keepAll ? "BUILD" : "PROJECT"; 
             listener.getLogger().println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
-            // The index name might be a comma separated list of names, so let's figure out all the pages we should index.
-            String[] csvReports = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
+            // The index name might be a comma separated list of names or include a pattern like "*.html", so let's figure out all the pages we should index.
+            FileSet fs = Util.createFileSet(new File(archiveDir.getRemote()), reportTarget.getReportFiles());
+            DirectoryScanner ds = fs.getDirectoryScanner();
+            String[] csvReports = ds.getIncludedFiles();
             ArrayList<String> reports = new ArrayList<String>();
             for (int j=0; j < csvReports.length; j++) {
                 String report = csvReports[j];

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -167,7 +167,7 @@ public class HtmlPublisher extends Recorder {
             listener.getLogger().println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
             // The index name might be a comma separated list of names or include a pattern like "*.html", so let's figure out all the pages we should index.
-            FileSet fs = Util.createFileSet(new File(archiveDir.getRemote()), reportTarget.getReportFiles());
+            FileSet fs = Util.createFileSet(new File(archiveDir.getRemote()), resolveParametersInString(build, listener, reportTarget.getReportFiles()));
             DirectoryScanner ds = fs.getDirectoryScanner();
             String[] csvReports = ds.getIncludedFiles();
             ArrayList<String> reports = new ArrayList<String>();


### PR DESCRIPTION
Thanks for this useful plugin.
When configuring the plugin on the admin UI we can list multiple index pages separated by a comma, for instance:

    page1.html,page2.html,page3.html

However we do not seem to be able to use [FileSet includes](http://ant.apache.org/manual/Types/fileset.html), for instance:

    *.html

FileSet includes are quite handy and seem to be used in many places in core Jenkins and plugins (for instance they are used in the [JUnit plugin](https://github.com/jenkinsci/junit-plugin)).
Why not support them ? Here is a pull request with a proposed changeset.