### PR TITLE
[JENKINS-29635] - Rework the configuration page of the HTML Publisher

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/config.jelly
@@ -1,70 +1,19 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:htmlpublisher="/htmlpublisher/lib">
   <!--
     This jelly script is used for per-project configuration.
 
     See global.jelly for a general discussion about jelly script.
   -->
-  <f:entry>
-  
-    <table width="100%">
-      <col width="20%"/>
-      <col width="20%"/>
-      <col width="15%"/>
-      <col width="12%"/>
-      <col width="12%"/>
-      <col width="12%"/>
-      <col width="9%"/>
-      <tr>
-        <td>HTML directory to archive</td>
-        <td>Index page[s]</td>
-        <td>Report title</td>
-        <td>Keep past HTML reports</td>
-        <td>Always link to last build on job page</td>
-        <td>Allow missing report</td>
-        <td/>
-      </tr>
-    </table>
-
-
-    <f:repeatable field="reportTargets">
-      <table width="100%">
-      <col width="20%"/>
-      <col width="20%"/>
-      <col width="15%"/>
-      <col width="12%"/>
-      <col width="12%"/>
-      <col width="12%"/>
-      <col width="9%"/>
-      <tr>
-        <td>
-          <f:textbox field="reportDir" />
-        </td>
-
-        <td>
-          <f:textbox field="reportFiles"  default="index.html"/>
-        </td>
-
-        <td>
-          <f:textbox field="reportName" default="HTML Report"/>
-        </td>
-
-        <td align="center">
-          <f:checkbox field="keepAll" />
-        </td>
-
-        <td align="center">
-          <f:checkbox field="alwaysLinkToLastBuild" />
-        </td>
-
-        <td align="center">
-          <f:checkbox field="allowMissing" />
-        </td>
-
-        <td>
-          <f:repeatableDeleteButton/>
-        </td>
-      </tr>
-      </table>
-    </f:repeatable>
+  <f:entry title="${%Reports}">
+    <!--TODO: migrate to the new version of repeatableProperty with invokeBody support-->
+    <htmlpublisher:repeatableProperty field="reportTargets">
+      <f:entry title=""> 
+        <div align="right"> 
+          <f:repeatableDeleteButton value="${%Delete report}"/> 
+        </div> 
+      </f:entry>
+    </htmlpublisher:repeatableProperty>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
@@ -1,0 +1,30 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" 
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  
+  <f:entry field="reportDir" title="${%reportDir.title}">
+    <f:textbox/>
+  </f:entry>
+
+  <f:entry field="reportFiles" title="${%reportFiles.title}">
+    <f:textbox default="index.html"/>
+  </f:entry>
+
+  <f:entry field="reportName" title="${%reportName.title}">
+    <f:textbox default="HTML Report"/>
+  </f:entry>
+
+  <f:advanced title="${%Publishing options}"> 
+    <f:entry field="keepAll" title="${%keepAll.title}">
+      <f:checkbox />
+    </f:entry>
+    
+    <f:entry field="alwaysLinkToLastBuild" title="${%alwaysLinkToLastBuild.title}">
+      <f:checkbox/>
+    </f:entry>
+    
+    <f:entry field="allowMissing" title="${%allowMissing.title}">
+      <f:checkbox/>
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
@@ -1,0 +1,6 @@
+reportDir.title=HTML directory to archive
+reportFiles.title=Index page[s]
+reportName.title=Report title
+keepAll.title=Keep past HTML reports
+alwaysLinkToLastBuild.title=Always link to last build
+allowMissing.title=Allow missing report

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-allowMissing.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-allowMissing.html
@@ -1,0 +1,3 @@
+<div>
+  If checked, will allow report to be missing and build will not fail on missing report
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-alwaysLinkToLastBuild.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-alwaysLinkToLastBuild.html
@@ -1,0 +1,4 @@
+<div>
+  If this control and &quot;Keep past HTML reports&quot; are checked, 
+  publish the link on project level even if build failed.
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-keepAll.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-keepAll.html
@@ -1,0 +1,3 @@
+<div>
+  If checked, archive reports for all successful builds, otherwise only the most recent
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportDir.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportDir.html
@@ -1,0 +1,3 @@
+<div>
+  The path to the HTML report directory relative to the workspace.
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportFiles.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportFiles.html
@@ -1,0 +1,3 @@
+<div>
+  The file(s) to provide links inside the report directory
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportName.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-reportName.html
@@ -1,0 +1,3 @@
+<div>
+  The name of the report to display for the build/project, such as &quot;Code Coverage&quot;
+</div>

--- a/src/main/resources/htmlpublisher/lib/repeatableProperty.jelly
+++ b/src/main/resources/htmlpublisher/lib/repeatableProperty.jelly
@@ -1,0 +1,39 @@
+<!--
+The MIT License
+
+Copyright (c) 2010, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!--
+This is a copy-paste of the tag from Jenkins core.
+It adds the <d:invokeBody> to the control - delete buttons can be declared outside the main configuration
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:repeatable field="${attrs.field}" default="${attrs.default}" noAddButton="${attrs.noAddButton}" header="${attrs.header}" add="${attrs.add}">
+    <table style="width:100%">
+      <st:include page="config.jelly" class="${descriptor.clazz}" />
+      <d:invokeBody/>
+    </table>
+  </f:repeatable>
+</j:jelly>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-29635

The original UI is very useful for small reports located in paths near the workspace. However, for long paths the interface is not comfortable due to small input windows.

I propose to migrate the UI to the classic Jenkins approach:
* vertical layout of controls with enough space for long directory paths
* help panels with additional info for users
* storage of UI controls within the HTMLPublisherTarget class
* usage of standard Jenkins controls => the plugin will be more tolerant against the ongoing rework of Jenkins core UIs

Current layout:
<img width="879" alt="screen shot 2015-07-25 at 11 34 26" src="https://cloud.githubusercontent.com/assets/3000480/8888709/5166513a-32c1-11e5-8e14-0bfefd9db0e5.png">

Proposed layout (with expanded "Advanced" section):
<img width="876" alt="screen shot 2015-07-25 at 11 29 38" src="https://cloud.githubusercontent.com/assets/3000480/8888710/56aba3e8-32c1-11e5-833a-f5264aa7e94a.png">

@reviewbybees @mrooney 
