### PR TITLE
[FIX JENKINS-32281] Consider multiple reports per build

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -218,7 +218,11 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
                     File javadocDir = getBuildArchiveDir(run);
 
                     if (javadocDir.exists()) {
-                        actualBuildAction = run.getAction(HTMLBuildAction.class);
+                        for (HTMLBuildAction a : run.getActions(HTMLBuildAction.class)) {
+                            if (a.getHTMLTarget().getReportName().equals(getHTMLTarget().getReportName())) {
+                                actualBuildAction = a;
+                            }
+                        }
                         return javadocDir;
                     }
                 }


### PR DESCRIPTION
When archiving multiple HTML reports per build, and accessing them through the project-level links, false-positive checksum mismatch errors appeared because the actions used whatever was the first report as reference.

Not as well tested as I'd like due to time constraints, but I wanted to get a possible fix to this issue out ASAP.

My apologies to @mrooney for introducing this boneheaded bug.

@reviewbybees 