### PR TITLE
Bump required Jenkins version to 1.642.3 not to confuse users what the requirement realy is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.1</version>
+    <version>1.642.3</version>
   </parent>
-  
+
   <properties>
     <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
     <workflow.version>1.4</workflow.version>
   </properties>
-  
+
   <licenses>
     <license>
       <name>The MIT License (MIT)</name>
@@ -62,9 +62,9 @@
             <executions>
               <execution>
                 <id>run-findbugs</id>
-                <phase>verify</phase> 
+                <phase>verify</phase>
                 <goals>
-                  <goal>check</goal> 
+                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>
@@ -128,7 +128,7 @@
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
-        <dependency> 
+        <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-aggregator</artifactId>
           <version>${workflow.version}</version>
@@ -147,6 +147,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-</project>  
-  
+</project>
+
 


### PR DESCRIPTION
It is expected by workflow-step-api and in Jenkins users get following warning: This plugin requires dependent plugins that are built for Jenkins 1.642.3 or newer. The dependent plugins may or may not work in your Jenkins and consequently this plugin may or may not work in your Jenkins.

CC @oleg-nenashev 