### PR TITLE
Allow user to set file includes pattern

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -263,7 +263,7 @@ public class HtmlPublisher extends Recorder {
                     targetDir.deleteRecursive();
                 }
 
-                if (archiveDir.copyRecursiveTo("**/*", targetDir) == 0 && !allowMissing) {
+                if (archiveDir.copyRecursiveTo(reportTarget.getIncludes(), targetDir) == 0 && !allowMissing) {
                     listener.error("Directory '" + archiveDir + "' exists but failed copying to '" + targetDir + "'.");
                     final Result buildResult = build.getResult();
                     if (buildResult != null && buildResult.isBetterOrEqualTo(Result.UNSTABLE)) {

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -26,6 +26,7 @@ import jenkins.model.RunAction2;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -78,6 +79,10 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
      * The name of the file which will be used as the wrapper index.
      */
     private static final String WRAPPER_NAME = "htmlpublisher-wrapper.html";
+
+    public static final String INCLUDE_ALL_PATTERN="**/*";
+
+    private String includes;
 
     /**
      * @deprecated Use {@link #HtmlPublisherTarget(java.lang.String, java.lang.String, java.lang.String, java.lang.String, boolean, boolean, boolean)}.
@@ -404,6 +409,35 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
 
     public Action getProjectAction(AbstractItem item) {
         return new HTMLAction(item, this);
+    }
+
+    /**
+     *
+     * @return the pattern for including files
+     */
+    public String getIncludes() {
+        return includes;
+    }
+
+    /**
+     *
+     * @param includes  Ant GLOB pattern
+     */
+    @DataBoundSetter
+    public void setIncludes(String includes) {
+        this.includes = includes;
+    }
+
+    /**
+     * Called by XStream after object construction
+     * @return modified object
+     */
+    protected Object readResolve() {
+        if (includes == null) {
+            //backward compatibility
+            includes = INCLUDE_ALL_PATTERN;
+        }
+        return this;
     }
 
     @Override

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -2,6 +2,7 @@ package htmlpublisher;
 
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.AbstractItem;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Action;
@@ -412,11 +413,14 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     }
 
     /**
-     *
-     * @return the pattern for including files
+     * @return the pattern for including files, default to all if no pattern specified
      */
     public String getIncludes() {
-        return includes;
+        if (Util.fixEmpty(includes) == null) {
+            return INCLUDE_ALL_PATTERN;
+        } else {
+            return includes;
+        }
     }
 
     /**

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
@@ -31,5 +31,8 @@
     <f:entry field="allowMissing" title="${%allowMissing.title}">
       <f:checkbox/>
     </f:entry>
+    <f:entry field="includes" title="${%reportFiles.includes}" description="${%reportFiles.includesHelp}">
+      <f:textbox default="**/*"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
@@ -1,6 +1,8 @@
 reportDir.title=HTML directory to archive
 reportFiles.title=Index page[s]
 reportTitles.title=Index page title[s] (Optional)
+reportFiles.includes=Include files
+reportFiles.includesHelp=Follows the Ant glob syntax, such as **/*.html,**/*.css
 reportName.title=Report title
 keepAll.title=Keep past HTML reports
 alwaysLinkToLastBuild.title=Always link to last build


### PR DESCRIPTION
We want to archive a html file builds/blah.html, but found out all the contents of builds folder were also copied from slave to master, I think add an include pattern will fix the issue.
The change is backward compatible
