### PR TITLE
Fix JENKINS-47034

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletException;
 
 import hudson.util.HttpResponses;
 import jenkins.model.RunAction2;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -111,10 +112,10 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
      */
     @DataBoundConstructor
     public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles,String reportTitles, boolean keepAll, boolean alwaysLinkToLastBuild, boolean allowMissing) {
-        this.reportName = reportName;
-        this.reportDir = reportDir;
-        this.reportFiles = reportFiles;
-        this.reportTitles = reportTitles;
+        this.reportName = StringUtils.trim(reportName);
+        this.reportDir = StringUtils.trim(reportDir);
+        this.reportFiles = StringUtils.trim(reportFiles);
+        this.reportTitles = StringUtils.trim(reportTitles);
         this.keepAll = keepAll;
         this.alwaysLinkToLastBuild = alwaysLinkToLastBuild;
         this.allowMissing = allowMissing;
@@ -132,12 +133,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
      * @since 1.4
      */
     public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles, boolean keepAll, boolean alwaysLinkToLastBuild, boolean allowMissing) {
-        this.reportName = reportName;
-        this.reportDir = reportDir;
-        this.reportFiles = reportFiles;
-        this.keepAll = keepAll;
-        this.alwaysLinkToLastBuild = alwaysLinkToLastBuild;
-        this.allowMissing = allowMissing;
+        this(reportName, reportDir, reportFiles, null, keepAll, alwaysLinkToLastBuild, allowMissing);
     }
 
     public String getReportName() {

--- a/src/test/groovy/htmlpublisher/HtmlPublisherIntegrationTest.groovy
+++ b/src/test/groovy/htmlpublisher/HtmlPublisherIntegrationTest.groovy
@@ -12,7 +12,7 @@ import org.jvnet.hudson.test.TestBuilder
  *
  * @author Kohsuke Kawaguchi
  */
-public class HtmlPublisherTest extends HudsonTestCase {
+public class HtmlPublisherIntegrationTest extends HudsonTestCase {
     /**
      * Makes sure that the configuration survives the round trip.
      */
@@ -66,14 +66,5 @@ public class HtmlPublisherTest extends HudsonTestCase {
         assertFalse(tab2Files.contains("dummy.html"))
     }
 
-    public void testDefaultIncludes() {
-        HtmlPublisherTarget target1 = new HtmlPublisherTarget("tab1", "target", "tab1.html", true, true, false);
-        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
-        target1.setIncludes(null);
-        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
-        target1.setIncludes("hello");
-        assertEquals("hello", target1.getIncludes());
-        target1.setIncludes("");
-        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
-    }
+
 }

--- a/src/test/java/htmlpublisher/HtmlPublisherTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherTest.java
@@ -1,0 +1,27 @@
+package htmlpublisher;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HtmlPublisherTest {
+    @Test
+    public void testDefaultIncludes() {
+        HtmlPublisherTarget target1 = new HtmlPublisherTarget("tab1", "target", "tab1.html", true, true, false);
+        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
+        target1.setIncludes(null);
+        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
+        target1.setIncludes("hello");
+        assertEquals("hello", target1.getIncludes());
+        target1.setIncludes("");
+        assertEquals(HtmlPublisherTarget.INCLUDE_ALL_PATTERN, target1.getIncludes());
+    }
+
+    @Test
+    public void testSpacesTrimmed() {
+        HtmlPublisherTarget target = new HtmlPublisherTarget("tab1 ", "target ", "tab1.html ", true, true, false);
+        assertEquals(target.getReportName(), "tab1");
+        assertEquals(target.getReportDir(), "target");
+        assertEquals(target.getReportFiles(), "tab1.html");
+    }
+}


### PR DESCRIPTION
Report Name, directory, files, and titles are now all trimmed. Note that
trimming is only done when configuration is saved.