### PR TITLE
Fix JENKINS-44786 - WIP

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -204,6 +204,8 @@ public class HtmlPublisher extends Recorder {
             boolean keepAll = reportTarget.getKeepAll();
             boolean allowMissing = reportTarget.getAllowMissing();
 
+            reportTarget.setActualReportName(resolveParametersInString(build, listener, reportTarget.getReportName()));
+
             FilePath archiveDir = workspace.child(resolveParametersInString(build, listener, reportTarget.getReportDir()));
             FilePath targetDir = reportTarget.getArchiveTarget(build);
 

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -233,13 +233,13 @@ public class HtmlPublisher extends Recorder {
                 String tabNo = "tab" + (j + 1);
                 // Make the report name the filename without the extension.
                 int end = report.lastIndexOf('.');
-                String reportName;
+                String reportFile;
                 if (end > 0) {
-                    reportName = report.substring(0, end);
+                    reportFile = report.substring(0, end);
                 } else {
-                    reportName = report;
+                    reportFile = report;
                 }
-                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" onclick=\"updateBody('" + tabNo + "');\" value=\"" + report + "\">" + getTitle(reportName, titles, j) + "</li>";
+                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" onclick=\"updateBody('" + tabNo + "');\" value=\"" + report + "\">" + getTitle(reportFile, titles, j) + "</li>";
                 reportLines.add(tabItem);
             }
             // Add the JS to change the link as appropriate.

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -216,6 +216,9 @@ public class HtmlPublisher extends Recorder {
             String[] titles = null;
             if (reportTarget.getReportTitles() != null && reportTarget.getReportTitles().trim().length() > 0 ) {
                 titles = reportTarget.getReportTitles().trim().split("\\s*,\\s*");
+                for (int j = 0; j < titles.length; j++) {
+                    titles[j] = resolveParametersInString(build, listener, titles[j]);
+                }
             }
 
             ArrayList<String> reports = new ArrayList<String>();

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -111,7 +111,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
      * @since 1.4
      */
     @DataBoundConstructor
-    public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles,String reportTitles, boolean keepAll, boolean alwaysLinkToLastBuild, boolean allowMissing) {
+    public HtmlPublisherTarget(String reportName, String reportDir, String reportFiles, String reportTitles, boolean keepAll, boolean alwaysLinkToLastBuild, boolean allowMissing) {
         this.reportName = StringUtils.trim(reportName);
         this.reportDir = StringUtils.trim(reportDir);
         this.reportFiles = StringUtils.trim(reportFiles);

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -186,17 +186,17 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     private File getBuildArchiveDir(Run run) {
         String reportName = "";
 
-        if (run != null) {
-            for (HTMLBuildAction a : run.getActions(HTMLBuildAction.class)) {
-                if (a.getHTMLTarget().getReportName().equals(this.getReportName())) {
-                    reportName = sanitizeName(a.actualReportName);
-                }
-            }
-            // If we don't have a reportName here, then this is getting called as part of a build
-            if ("".equals(reportName)) {
-                reportName = this.getSanitizedName();
+        for (HTMLBuildAction a : run.getActions(HTMLBuildAction.class)) {
+            if (a.getHTMLTarget().getReportName().equals(this.getReportName())) {
+                reportName = sanitizeName(a.actualReportName);
             }
         }
+
+        // If we don't have a reportName here, then this is getting called as part of a build
+        if ("".equals(reportName)) {
+            reportName = this.getSanitizedName();
+        }
+
         return new File(new File(run.getRootDir(), "htmlreports"), reportName);
     }
 


### PR DESCRIPTION
Previously only the report directory and index pages fields had parameter expansion. This change allows the HTML directory, index pages, index page titles, and report title to all have parameters passed in.

CC/ @jenkinsci/code-reviewers - keen to get a review on the changes being made as the report title (aka report name in the code) change was a bit hairy and want to make sure I'm not doing anything really bad.

Still to add some tests & do some backward compatibility tests so this PR is still to get some updates.