### PR TITLE
Allow underscore in report name

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -181,7 +181,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
 
     @Restricted(NoExternalUse.class)
     public static String sanitizeReportName(String reportName) {
-        Pattern p = Pattern.compile("[^a-zA-Z0-9-]");
+        Pattern p = Pattern.compile("[^a-zA-Z0-9-_]");
         Matcher m = p.matcher(reportName);
         StringBuffer sb = new StringBuffer();
         while (m.find()) {


### PR DESCRIPTION
Add the possibility to create the same report name as version 1.15 and lower when a space or underscore was used in the name.