### PR TITLE
adding backToName and backToUrl variables

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -244,6 +244,14 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
             return dir().exists() ? "graph.gif" : null;
         }
 
+        public String getBackToName() {
+            return project.getDisplayName();
+        }
+
+        public String getBackToUrl() {
+            return project.getUrl();
+        }
+
         public boolean shouldLinkToLastBuild() {
             return actualHtmlPublisherTarget.getAlwaysLinkToLastBuild();
         }
@@ -398,6 +406,16 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         @Override
         protected String getTitle() {
             return this.build.getDisplayName() + " html3";
+        }
+
+        @Override
+        public String getBackToName() {
+            return build.getDisplayName();
+        }
+
+        @Override
+        public String getBackToUrl() {
+            return build.getUrl();
         }
 
         @Override

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
@@ -42,8 +42,8 @@ def serveWrapper() {
     }
 
     // TODO replace unnecessary JS usage by properly integrating header.html/footer.html in this groovy view
-    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").innerHTML=\"Back to ${my.project.displayName}\";</script>")
-    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").href=\"${rootURL}/${my.project.url}\";</script>")
+    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").innerHTML=\"Back to ${my.backToName}\";</script>")
+    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").href=\"${rootURL}/${my.backToUrl}\";</script>")
     raw("<script type=\"text/javascript\">document.getElementById(\"zip_link\").href=\"*zip*/${my.getHTMLTarget().sanitizedName}.zip\";</script>")
 
     raw(footer)


### PR DESCRIPTION
When viewing HTML Report connected to build it is convenient to be
able to use "Back To ..." option to return to build not to the project.
This commit adds additional methods to BaseHTMLAction and overrides in
HTMLBuildAction. Thanks to that we can easily go back to project or to
build accordingly.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>