### PR TITLE
fix display issues for many tabs

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -20,7 +20,7 @@ margin: 8px 0 0 0; /* set margins as desired */
 font: bold 11px verdana, arial, sans-serif; /* set font as desired */
 border-bottom: 1px solid #6c6; /* set border COLOR as desired */
 list-style-type: none;
-padding: 3px 10px 3px 10px; /* THIRD number must change with respect to padding-top (X) below */
+padding: 3px 10px 0px 10px;
 }
 
 ul#tabnav li { /* do not change */
@@ -34,13 +34,13 @@ background-color: #fff; /* set background color to match above border color */
 
 
 ul#tabnav li { /* settings for all tab links */
-padding: 3px 4px; /* set padding (tab size) as desired; FIRST number must change with respect to padding-top (X) above */
+padding: 3px 4px;
 border: 1px solid #6c6; /* set border COLOR as desired; usually matches border color specified in #tabnav */
+border-bottom: 1px solid #cfc;
 background-color: #cfc; /* set unselected tab background color as desired */
 color: #666; /* set unselected tab link color as desired */
 margin-right: 0px; /* set additional spacing between tabs as desired */
 text-decoration: none;
-border-bottom: none;
 cursor: pointer;
 }
 

--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -24,7 +24,7 @@ padding: 3px 10px 3px 10px; /* THIRD number must change with respect to padding-
 }
 
 ul#tabnav li { /* do not change */
-display: inline;
+display: inline-block;
 }
 
 ul#tabnav li.selected { /* settings for selected tab */


### PR DESCRIPTION
When you have many tabs in your HTML reports, they start to overlap. This simple fix makes them more user-friendly while keeping preferred "inline" bahaviour.

## Before
<img width="1439" alt="screen shot 2018-11-02 at 14 44 00" src="https://user-images.githubusercontent.com/1889755/47919011-962ce300-deae-11e8-9277-224199f5be32.png">

## After
<img width="1440" alt="screen shot 2018-11-02 at 14 44 25" src="https://user-images.githubusercontent.com/1889755/47919012-96c57980-deae-11e8-9819-9d7e8e0c04e9.png">
