### PR TITLE
Enable use of Ant style wildcards for index files

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -334,7 +334,6 @@ public class HtmlPublisher extends Recorder {
                 e.printStackTrace();
             }
         }
-
         return true;
     }
 

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -232,17 +232,17 @@ public class HtmlPublisher extends Recorder {
             String levelString = keepAll ? "BUILD" : "PROJECT";
             listener.getLogger().println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
-			// Index files might be a list of ant patters, e.g. "**/*index.html, **/*otherFile.html"
-			// So split them and search for files within the archive directory that match that pattern
-			List<String> csvReports = new ArrayList<>();
-			File archiveDirFile = new File(archiveDir.getRemote());
-			if (archiveDirFile.exists()) {
-				String[] splittedPatterns = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
-				for (String pattern : splittedPatterns) {
-					FileSet fs = Util.createFileSet(archiveDirFile, pattern);
-					csvReports.addAll(Arrays.asList(fs.getDirectoryScanner().getIncludedFiles()));
-				}
-			}
+            // Index files might be a list of ant patters, e.g. "**/*index.html,**/*otherFile.html"
+            // So split them and search for files within the archive directory that match that pattern
+            List<String> csvReports = new ArrayList<>();
+            File archiveDirFile = new File(archiveDir.getRemote());
+            if (archiveDirFile.exists()) {
+                String[] splittedPatterns = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
+                for (String pattern : splittedPatterns) {
+                    FileSet fs = Util.createFileSet(archiveDirFile, pattern);
+                    csvReports.addAll(Arrays.asList(fs.getDirectoryScanner().getIncludedFiles()));
+                }
+            }
 
             String[] titles = null;
             if (reportTarget.getReportTitles() != null && reportTarget.getReportTitles().trim().length() > 0 ) {

--- a/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
@@ -111,36 +111,32 @@ public class HtmlPublisherIntegrationTest {
         assertTrue(tab2Files.contains("afile.html"));
     }
 
-    
-	@Test
-	public void testWithWildcardPatterns() throws Exception {
-		FreeStyleProject p = j.createFreeStyleProject("variable_job");
-		final String reportDir = "autogen";
-		p.getBuildersList().add(new TestBuilder() {
-			public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-					throws InterruptedException, IOException {
-				FilePath ws = build.getWorkspace().child(reportDir);
-				ws.child("nested1").child("aReportDir").child("nested").child("afile.html").write("hello", "UTF-8");
-				ws.child("notincluded").child("afile.html").write("hello", "UTF-8");
-				ws.child("otherDir").child("afile.html").write("hello", "UTF-8");
-				return true;
-			}
-		});
-		HtmlPublisherTarget target2 = new HtmlPublisherTarget("reportname", reportDir,
-				"**/aReportDir/*/afile.html, **/otherDir/afile.html", "A title", true, true, false);
-		List<HtmlPublisherTarget> targets = new ArrayList<>();
-		targets.add(target2);
-		p.getPublishersList().add(new HtmlPublisher(targets));
-		AbstractBuild build = j.buildAndAssertSuccess(p);
-		File wrapperFile = new File(build.getRootDir(), "htmlreports/reportname/htmlpublisher-wrapper.html");
-		assertTrue(wrapperFile.exists());
-		String content = new String(Files.readAllBytes(wrapperFile.toPath()));
-		assertTrue(content.contains("nested1/aReportDir/nested/afile.html"));
-		assertTrue(content.contains("otherDir/afile.html"));
-		assertFalse(content.contains("notincluded/afile.html"));
+    @Test
+    public void testWithWildcardPatterns() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject("variable_job");
+        final String reportDir = "autogen";
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                FilePath ws = build.getWorkspace().child(reportDir);
+                ws.child("nested1").child("aReportDir").child("nested").child("afile.html").write("hello", "UTF-8");
+                ws.child("notincluded").child("afile.html").write("hello", "UTF-8");
+                ws.child("otherDir").child("afile.html").write("hello", "UTF-8");
+                return true;
+            }
+        });
+        HtmlPublisherTarget target2 = new HtmlPublisherTarget("reportname", reportDir, "**/aReportDir/*/afile.html, **/otherDir/afile.html", "A title", true, true, false);
+        List<HtmlPublisherTarget> targets = new ArrayList<>();
+        targets.add(target2);
+        p.getPublishersList().add(new HtmlPublisher(targets));
+        AbstractBuild build = j.buildAndAssertSuccess(p);
+        File wrapperFile = new File(build.getRootDir(), "htmlreports/reportname/htmlpublisher-wrapper.html");
+        assertTrue(wrapperFile.exists());
+        String content = new String(Files.readAllBytes(wrapperFile.toPath()));
+        assertTrue(content.contains("nested1/aReportDir/nested/afile.html"));
+        assertTrue(content.contains("otherDir/afile.html"));
+        assertFalse(content.contains("notincluded/afile.html"));
+    }
 
-	}
-    
     private void addEnvironmentVariable(String key, String value) {
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars envVars = prop.getEnvVars();


### PR DESCRIPTION
Allow that `reportDir` could process expressions like this `**/reportdir/**/index.html`