### PR TITLE
Increment minimum versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jdkVersions: [8])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jdkVersions: [7, 8])
+buildPlugin(jdkVersions: [8])

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.29</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
   
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <workflow.version>1.14.2</workflow.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.150.3</jenkins.version>
+    <java.level>8</java.level>
+    <jenkins-test-harness.version>2.55</jenkins-test-harness.version>
   </properties>
   
   <licenses>
@@ -87,31 +87,31 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-step-api</artifactId>
-          <version>${workflow.version}</version>
+          <version>2.19</version>
         </dependency>
         <dependency> <!-- Test framework -->
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-step-api</artifactId>
-          <version>${workflow.version}</version>
+          <version>2.19</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency> 
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-job</artifactId>
-          <version>${workflow.version}</version>
+          <version>2.31</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-cps</artifactId>
-          <version>${workflow.version}</version>
+          <version>2.63</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-durable-task-step</artifactId>
-          <version>${workflow.version}</version>
+          <version>2.29</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,8 +123,22 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>annotation-indexer</artifactId>
-            <version>1.9</version>
+            <version>1.12</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>2.33</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-support</artifactId>
+                <version>3.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <licenses>
     <license>
       <name>The MIT License (MIT)</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -27,7 +27,7 @@
   <version>1.21-SNAPSHOT</version>
   <name>HTML Publisher plugin</name>
   <description>This plugin publishes HTML reports.</description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin</url>
   <developers>
       <developer>
           <id>r2b2_nz</id>
@@ -67,14 +67,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -87,31 +87,26 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-step-api</artifactId>
-          <version>2.19</version>
         </dependency>
         <dependency> <!-- Test framework -->
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-step-api</artifactId>
-          <version>2.19</version>
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
         <dependency> 
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-job</artifactId>
-          <version>2.31</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-cps</artifactId>
-          <version>2.63</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-durable-task-step</artifactId>
-          <version>2.29</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,15 +125,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-api</artifactId>
-                <version>2.33</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-support</artifactId>
-                <version>3.2</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.150.x</artifactId>
+                <version>3</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
-</project>  
+</project>

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -117,6 +118,7 @@ public class HtmlPublisher extends Recorder {
         return readFile(filePath, this.getClass());
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "Apparent false positive on JDK11 on try block")
     public static List<String> readFile(String filePath, Class<?> publisherClass)
             throws java.io.IOException {
         List<String> aList = new ArrayList<>();


### PR DESCRIPTION
Change HTML Publisher to be baselined off of 2.150.3 as the majority of users are now using this version or above. 

As part of this change this also means a switch to Java 8 building and also it incorporates the http to https switch originally proposed by @daniel-beck in https://github.com/jenkinsci/htmlpublisher-plugin/pull/46 (plus http-to-https-ifies the other URLs too).