### PR TITLE
Enable use of Ant style wildcards for index files

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -68,7 +69,10 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
+
+import org.apache.tools.ant.types.FileSet;
 import jenkins.model.Jenkins;
+
 
 /**
  * Saves HTML reports for the project and publishes them.
@@ -216,8 +220,17 @@ public class HtmlPublisher extends Recorder {
             String levelString = keepAll ? "BUILD" : "PROJECT";
             logger.println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
-            // The index name might be a comma separated list of names, so let's figure out all the pages we should index.
-            String[] csvReports = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
+            // Index files might be a list of ant patterns, e.g. "**/*index.html,**/*otherFile.html"
+            // So split them and search for files within the archive directory that match that pattern
+            List<String> csvReports = new ArrayList<>();
+            File archiveDirFile = new File(archiveDir.getRemote());
+            if (archiveDirFile.exists()) {
+                String[] splitPatterns = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
+                for (String pattern : splitPatterns) {
+                    FileSet fs = Util.createFileSet(archiveDirFile, pattern);
+                    csvReports.addAll(Arrays.asList(fs.getDirectoryScanner().getIncludedFiles()));
+                }
+            }
 
             String[] titles = null;
             if (reportTarget.getReportTitles() != null && reportTarget.getReportTitles().trim().length() > 0 ) {
@@ -228,10 +241,13 @@ public class HtmlPublisher extends Recorder {
             }
 
             List<String> reports = new ArrayList<>();
-            for (int j=0; j < csvReports.length; j++) {
-                String report = csvReports[j];
+            for (int j=0; j < csvReports.size(); j++) {
+                String report = csvReports.get(j);
                 report = report.trim();
-
+                // On windows file paths contains back slashes, but
+                // in the HTML file we do not want them, so replace them with forward slash
+                report = report.replace("\\", "/");
+	
                 // Ignore blank report names caused by trailing or double commas.
                 if (report.isEmpty()) {
                     continue;
@@ -308,7 +324,6 @@ public class HtmlPublisher extends Recorder {
                 logger.println("Error: NoSuchAlgorithmException occured writing report to file "+outputFile.getAbsolutePath()+" to archiveDir:"+archiveDir.getName()+", error:"+e.getMessage());
             }
         }
-
         return true;
     }
 

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -196,14 +196,14 @@ public class HtmlPublisher extends Recorder {
         try {
             headerLines = readFile(HEADER, publisherClass);
         } catch (IOException ex) {
-            logger.print("Exception occured reading file "+HEADER+", message:"+ex.getMessage());
+            logger.print("Exception occurred reading file "+HEADER+", message:"+ex.getMessage());
             return false;
         }
         List<String> footerLines;
         try {
             footerLines = readFile(FOOTER, publisherClass);
         } catch (IOException ex) {
-            logger.print("Exception occured reading file "+FOOTER+", message:"+ex.getMessage());
+            logger.print("Exception occurred reading file "+FOOTER+", message:"+ex.getMessage());
             return false;
         }
 
@@ -224,11 +224,9 @@ public class HtmlPublisher extends Recorder {
             try {
                 if (!archiveDir.exists()) {
                     listener.error("Specified HTML directory '" + archiveDir + "' does not exist.");
-
                     if (!allowMissing) {
                         build.setResult(Result.FAILURE);
                     }
-
                     return true;
                 }
 
@@ -246,7 +244,6 @@ public class HtmlPublisher extends Recorder {
                         }
                         build.setResult(Result.FAILURE);
                     }
-
                     return true;
                 }
             } catch (IOException e) {

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -207,6 +207,7 @@ public class HtmlPublisher extends Recorder {
             return false;
         }
 
+
         for (int i=0; i < reportTargets.size(); i++) {
             // Create an array of lines we will eventually write out, initially the header.
             List<String> reportLines = new ArrayList<>(headerLines);
@@ -220,16 +221,49 @@ public class HtmlPublisher extends Recorder {
             String levelString = keepAll ? "BUILD" : "PROJECT";
             logger.println("[htmlpublisher] Archiving at " + levelString + " level " + archiveDir + " to " + targetDir);
 
+            try {
+                if (!archiveDir.exists()) {
+                    listener.error("Specified HTML directory '" + archiveDir + "' does not exist.");
+
+                    if (!allowMissing) {
+                        build.setResult(Result.FAILURE);
+                    }
+
+                    return true;
+                }
+
+                if (!keepAll) {
+                    // We are only keeping one copy at the project level, so remove the old one.
+                    targetDir.deleteRecursive();
+                }
+
+                if (archiveDir.copyRecursiveTo(reportTarget.getIncludes(), targetDir) == 0) {
+                    if (!allowMissing) {
+                        listener.error("Directory '" + archiveDir + "' exists but failed copying to '" + targetDir + "'.");
+                        final Result buildResult = build.getResult();
+                        if (buildResult != null && buildResult.isBetterOrEqualTo(Result.UNSTABLE)) {
+                            listener.error("This is especially strange since your build otherwise succeeded.");
+                        }
+                        build.setResult(Result.FAILURE);
+                    }
+
+                    return true;
+                }
+            } catch (IOException e) {
+                Util.displayIOException(e, listener);
+                e.printStackTrace(listener.fatalError("HTML Publisher failure"));
+                build.setResult(Result.FAILURE);
+                return true;
+            }
+
             // Index files might be a list of ant patterns, e.g. "**/*index.html,**/*otherFile.html"
             // So split them and search for files within the archive directory that match that pattern
             List<String> csvReports = new ArrayList<>();
-            File archiveDirFile = new File(archiveDir.getRemote());
-            if (archiveDirFile.exists()) {
-                String[] splitPatterns = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
-                for (String pattern : splitPatterns) {
-                    FileSet fs = Util.createFileSet(archiveDirFile, pattern);
-                    csvReports.addAll(Arrays.asList(fs.getDirectoryScanner().getIncludedFiles()));
-                }
+            File targetDirFile = new File(targetDir.getRemote());
+            String[] splitPatterns = resolveParametersInString(build, listener, reportTarget.getReportFiles()).split(",");
+            for (String pattern : splitPatterns) {
+                FileSet fs = Util.createFileSet(targetDirFile, pattern);
+                csvReports.addAll(Arrays.asList(fs.getDirectoryScanner().getIncludedFiles()));
             }
 
             String[] titles = null;
@@ -279,34 +313,6 @@ public class HtmlPublisher extends Recorder {
             }
 
             reportLines.add("<script type=\"text/javascript\">document.getElementById(\"zip_link\").href=\"*zip*/" + reportTarget.getSanitizedName() + ".zip\";</script>");
-
-            try {
-                if (!archiveDir.exists() && !allowMissing) {
-                    listener.error("Specified HTML directory '" + archiveDir + "' does not exist.");
-                    build.setResult(Result.FAILURE);
-                    return true;
-                } else if (!keepAll) {
-                    // We are only keeping one copy at the project level, so remove the old one.
-                    targetDir.deleteRecursive();
-                }
-
-                if (archiveDir.copyRecursiveTo(reportTarget.getIncludes(), targetDir) == 0 && !allowMissing) {
-                    listener.error("Directory '" + archiveDir + "' exists but failed copying to '" + targetDir + "'.");
-                    final Result buildResult = build.getResult();
-                    if (buildResult != null && buildResult.isBetterOrEqualTo(Result.UNSTABLE)) {
-                        // If the build failed, don't complain that there was no coverage.
-                        // The build probably didn't even get to the point where it produces coverage.
-                        listener.error("This is especially strange since your build otherwise succeeded.");
-                    }
-                    build.setResult(Result.FAILURE);
-                    return true;
-                }
-            } catch (IOException e) {
-                Util.displayIOException(e, listener);
-                e.printStackTrace(listener.fatalError("HTML Publisher failure"));
-                build.setResult(Result.FAILURE);
-                return true;
-            }
 
             // Now add the footer.
             reportLines.addAll(footerLines);

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -225,7 +225,6 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         return getBuildArchiveDir(run, getSanitizedName());
     }
 
-
     private File getBuildArchiveDir(Run run, String dirName) {
         return new File(new File(run.getRootDir(), "htmlreports"), dirName);
     }

--- a/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
@@ -14,6 +14,7 @@ import org.jvnet.hudson.test.TestBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -109,6 +110,32 @@ public class HtmlPublisherIntegrationTest {
         assertNotNull(new File(base, "reportname").list());
         List<String> tab2Files = Arrays.asList(new File(base, "reportname").list());
         assertTrue(tab2Files.contains("afile.html"));
+    }
+
+    @Test
+    public void testWithWildcardPatterns() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject("variable_job");
+        final String reportDir = "autogen";
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                FilePath ws = build.getWorkspace().child(reportDir);
+                ws.child("nested1").child("aReportDir").child("nested").child("afile.html").write("hello", "UTF-8");
+                ws.child("notincluded").child("afile.html").write("hello", "UTF-8");
+                ws.child("otherDir").child("afile.html").write("hello", "UTF-8");
+                return true;
+            }
+        });
+        HtmlPublisherTarget target2 = new HtmlPublisherTarget("reportname", reportDir, "**/aReportDir/*/afile.html, **/otherDir/afile.html", true, true, false);
+        List<HtmlPublisherTarget> targets = new ArrayList<>();
+        targets.add(target2);
+        p.getPublishersList().add(new HtmlPublisher(targets));
+        AbstractBuild build = j.buildAndAssertSuccess(p);
+        File wrapperFile = new File(build.getRootDir(), "htmlreports/reportname/htmlpublisher-wrapper.html");
+        assertTrue(wrapperFile.exists());
+        String content = new String(Files.readAllBytes(wrapperFile.toPath()));
+        assertTrue(content.contains("nested1/aReportDir/nested/afile.html"));
+        assertTrue(content.contains("otherDir/afile.html"));
+        assertFalse(content.contains("notincluded/afile.html"));
     }
 
     private void addEnvironmentVariable(String key, String value) {


### PR DESCRIPTION
Rework work done before (see https://github.com/jenkinsci/htmlpublisher-plugin/pull/43) to work in an environment that has workloads running on agents. 

@carlosgv87 as the previous PR submitter, would be good to get you to check out this PR just to make sure that I haven't missed anything that you've done previously in my Git'ing around.