### PR TITLE
Switch to adding or replacing build action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
             <version>1.13</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -278,6 +278,19 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         protected abstract String getTitle();
 
         protected abstract File dir();
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            BaseHTMLAction that = (BaseHTMLAction) o;
+            return Objects.equals(actualHtmlPublisherTarget, that.actualHtmlPublisherTarget);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(actualHtmlPublisherTarget);
+        }
     }
 
     public class HTMLAction extends BaseHTMLAction implements ProminentProjectAction {
@@ -478,9 +491,9 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         if (this.keepAll) {
             HTMLBuildAction a = new HTMLBuildAction(build, this);
             a.setWrapperChecksum(checksum);
-            build.addAction(a);
-        } else { // Othwewise we add a hidden marker
-            build.addAction(new HTMLPublishedForProjectMarkerAction(build, this));
+            build.addOrReplaceAction(a);
+        } else { // Otherwise we add a hidden marker
+            build.addOrReplaceAction(new HTMLPublishedForProjectMarkerAction(build, this));
         }
     }
 
@@ -524,11 +537,6 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     public int hashCode() {
         int hash = 5;
         hash = 97 * hash + (this.reportName != null ? this.reportName.hashCode() : 0);
-        hash = 97 * hash + (this.reportDir != null ? this.reportDir.hashCode() : 0);
-        hash = 97 * hash + (this.reportFiles != null ? this.reportFiles.hashCode() : 0);
-        hash = 97 * hash + (this.alwaysLinkToLastBuild ? 1 : 0);
-        hash = 97 * hash + (this.keepAll ? 1 : 0);
-        hash = 97 * hash + (this.allowMissing ? 1 : 0);
         return hash;
     }
 
@@ -544,21 +552,7 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         if (!Objects.equals(this.reportName, other.reportName)) {
             return false;
         }
-        if (!Objects.equals(this.reportDir, other.reportDir)) {
-            return false;
-        }
-        if (!Objects.equals(this.reportFiles, other.reportFiles)) {
-            return false;
-        }
-        if (this.alwaysLinkToLastBuild != other.alwaysLinkToLastBuild) {
-            return false;
-        }
-        if (this.keepAll != other.keepAll) {
-            return false;
-        }
-        if (this.allowMissing != other.allowMissing) {
-            return false;
-        }
+
         return true;
     }
 

--- a/src/test/java/htmlpublisher/HtmlPublisherTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherTest.java
@@ -1,6 +1,10 @@
 package htmlpublisher;
 
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,5 +37,25 @@ public class HtmlPublisherTest {
         // test underscores not escaped when not requested
         assertEquals(HtmlPublisherTarget.sanitizeReportName("foo_bar", false), HtmlPublisherTarget.sanitizeReportName("foo_bar", false));
 
+    }
+
+    @Test
+    public void testActionEqual() {
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+
+        HtmlPublisherTarget targetOne = new HtmlPublisherTarget("tab1 ", "target ", "tab1.html ", true, true, false);
+        assertEquals(targetOne.getReportName(), "tab1");
+        assertEquals(targetOne.getReportDir(), "target");
+        assertEquals(targetOne.getReportFiles(), "tab1.html");
+
+        HtmlPublisherTarget targetTwo = new HtmlPublisherTarget("tab1 ", "target ", "tab1.html ", true, true, false);
+        assertEquals(targetTwo.getReportName(), "tab1");
+        assertEquals(targetTwo.getReportDir(), "target");
+        assertEquals(targetTwo.getReportFiles(), "tab1.html");
+
+        HtmlPublisherTarget.HTMLBuildAction actionOne = targetOne.new HTMLBuildAction(build, targetOne);
+        HtmlPublisherTarget.HTMLBuildAction actionTwo = targetOne.new HTMLBuildAction(build, targetTwo);
+
+        assertEquals(actionOne, actionTwo);
     }
 }


### PR DESCRIPTION
Currently build actions are added only and so, if the same action is called multiple times, multiple build actions appear in the navigation. This change is to make a subsequent call replace the previously created action.