### PR TITLE
Delete unused gmavenplus-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,20 +54,6 @@
                  <goals>deploy</goals>
              </configuration>
           </plugin>
-          <plugin> <!-- TODO otherwise Groovy tests are uncompilable; cf. similar hack in workflow-cps -->
-            <groupId>org.codehaus.gmavenplus</groupId>
-            <artifactId>gmavenplus-plugin</artifactId>
-            <version>1.9.0</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>addTestSources</goal>
-                  <goal>generateTestStubs</goal>
-                  <goal>compileTests</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
       </plugins>
   </build>
 


### PR DESCRIPTION
Despite #42 it seems this was obsolete since #32 which actually deleted Groovy tests.