### PR TITLE
Revert "Switch to adding or replacing build action"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,6 @@
             <version>1.14</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -278,19 +278,6 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         protected abstract String getTitle();
 
         protected abstract File dir();
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            BaseHTMLAction that = (BaseHTMLAction) o;
-            return Objects.equals(actualHtmlPublisherTarget, that.actualHtmlPublisherTarget);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(actualHtmlPublisherTarget);
-        }
     }
 
     public class HTMLAction extends BaseHTMLAction implements ProminentProjectAction {
@@ -491,9 +478,9 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         if (this.keepAll) {
             HTMLBuildAction a = new HTMLBuildAction(build, this);
             a.setWrapperChecksum(checksum);
-            build.addOrReplaceAction(a);
-        } else { // Otherwise we add a hidden marker
-            build.addOrReplaceAction(new HTMLPublishedForProjectMarkerAction(build, this));
+            build.addAction(a);
+        } else { // Othwewise we add a hidden marker
+            build.addAction(new HTMLPublishedForProjectMarkerAction(build, this));
         }
     }
 
@@ -537,6 +524,11 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     public int hashCode() {
         int hash = 5;
         hash = 97 * hash + (this.reportName != null ? this.reportName.hashCode() : 0);
+        hash = 97 * hash + (this.reportDir != null ? this.reportDir.hashCode() : 0);
+        hash = 97 * hash + (this.reportFiles != null ? this.reportFiles.hashCode() : 0);
+        hash = 97 * hash + (this.alwaysLinkToLastBuild ? 1 : 0);
+        hash = 97 * hash + (this.keepAll ? 1 : 0);
+        hash = 97 * hash + (this.allowMissing ? 1 : 0);
         return hash;
     }
 
@@ -552,7 +544,21 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         if (!Objects.equals(this.reportName, other.reportName)) {
             return false;
         }
-
+        if (!Objects.equals(this.reportDir, other.reportDir)) {
+            return false;
+        }
+        if (!Objects.equals(this.reportFiles, other.reportFiles)) {
+            return false;
+        }
+        if (this.alwaysLinkToLastBuild != other.alwaysLinkToLastBuild) {
+            return false;
+        }
+        if (this.keepAll != other.keepAll) {
+            return false;
+        }
+        if (this.allowMissing != other.allowMissing) {
+            return false;
+        }
         return true;
     }
 

--- a/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
@@ -205,35 +205,12 @@ public class HtmlPublisherIntegrationTest {
         assertTrue(new File(build.getRootDir(), "htmlreports/reportnameB/htmlpublisher-wrapper.html").exists());
     }
 
-    public void testActionsUpdated() throws Exception {
-        FreeStyleProject p = j.createFreeStyleProject("variable_job");
-        final String reportDir = "autogen";
-        p.getBuildersList().add(new TestBuilder() {
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-                FilePath ws = build.getWorkspace().child(reportDir);
-                ws.child("nested1").child("aReportDir").child("nested").child("afile.html").write("hello", "UTF-8");
-                ws.child("notincluded").child("afile.html").write("hello", "UTF-8");
-                ws.child("otherDir").child("afile.html").write("hello", "UTF-8");
-                return true;
-            }
-        });
-        HtmlPublisherTarget target1 = new HtmlPublisherTarget("reportname", reportDir, "**/aReportDir/*/afile.html, **/otherDir/afile.html", true, true, false);
-        HtmlPublisherTarget target2 = new HtmlPublisherTarget("reportname", reportDir, "**/aReportDir/*/afile.html, **/otherDir/afile.html", true, true, false);
-
-        List<HtmlPublisherTarget> targets = new ArrayList<>();
-        targets.add(target1);
-        targets.add(target2);
-        p.getPublishersList().add(new HtmlPublisher(targets));
-        AbstractBuild build = j.buildAndAssertSuccess(p);
-
-        List<HtmlPublisherTarget.HTMLBuildAction> actions = build.getActions(HtmlPublisherTarget.HTMLBuildAction.class);
-        assertEquals("Action count incorrect", 1, actions.size());
-    }
-
     private void addEnvironmentVariable(String key, String value) {
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars envVars = prop.getEnvVars();
         envVars.put(key, value);
         j.jenkins.getGlobalNodeProperties().add(prop);
     }
+
+
 }

--- a/src/test/java/htmlpublisher/HtmlPublisherTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherTest.java
@@ -1,10 +1,6 @@
 package htmlpublisher;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.FreeStyleProject;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 
@@ -37,25 +33,5 @@ public class HtmlPublisherTest {
         // test underscores not escaped when not requested
         assertEquals(HtmlPublisherTarget.sanitizeReportName("foo_bar", false), HtmlPublisherTarget.sanitizeReportName("foo_bar", false));
 
-    }
-
-    @Test
-    public void testActionEqual() {
-        AbstractBuild build = Mockito.mock(AbstractBuild.class);
-
-        HtmlPublisherTarget targetOne = new HtmlPublisherTarget("tab1 ", "target ", "tab1.html ", true, true, false);
-        assertEquals(targetOne.getReportName(), "tab1");
-        assertEquals(targetOne.getReportDir(), "target");
-        assertEquals(targetOne.getReportFiles(), "tab1.html");
-
-        HtmlPublisherTarget targetTwo = new HtmlPublisherTarget("tab1 ", "target ", "tab1.html ", true, true, false);
-        assertEquals(targetTwo.getReportName(), "tab1");
-        assertEquals(targetTwo.getReportDir(), "target");
-        assertEquals(targetTwo.getReportFiles(), "tab1.html");
-
-        HtmlPublisherTarget.HTMLBuildAction actionOne = targetOne.new HTMLBuildAction(build, targetOne);
-        HtmlPublisherTarget.HTMLBuildAction actionTwo = targetOne.new HTMLBuildAction(build, targetTwo);
-
-        assertEquals(actionOne, actionTwo);
     }
 }


### PR DESCRIPTION
This reverts commit 2360af32e5794374bc2b29c8752a9d24f13159b5.

The new functionality just didn't work and caused more problems than it was attempting to solve.