### PR TITLE
[JENKINS-65028] URL encode the html file name

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -81,7 +81,7 @@ function updateBody(tabId, page) {
     tab.setAttribute("class", "selected");
     selectedTab = tabId;
     iframe = document.getElementById("myframe");
-    iframe.src = tab.getAttribute("value");
+    iframe.src = encodeURIComponent(tab.getAttribute("value"));
 }
 function init(tabId){
 	updateBody(tabId);

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -24,7 +24,7 @@ public class HtmlFileNameTest {
 
         FreeStyleProject job = j.createFreeStyleProject();
 
-        job.getBuildersList().add(new CreateFileBuilder("#$&+,:;= ?@.html", content));
+        job.getBuildersList().add(new CreateFileBuilder("#$&+,;= ?@.html", content));
         job.getPublishersList().add(new HtmlPublisher(Arrays.asList(
             new HtmlPublisherTarget("report-name", "", "*.html", true, true, false))));
         job.save();
@@ -33,12 +33,12 @@ public class HtmlFileNameTest {
 
         JenkinsRule.WebClient client = j.createWebClient();
         assertEquals(content,
-            client.getPage(job, "report-name/%23%24%26%2B%2C%3A%3B%3D%20%3F%40.html").getWebResponse().getContentAsString());
+            client.getPage(job, "report-name/%23%24%26%2B%2C%3B%3D%20%3F%40.html").getWebResponse().getContentAsString());
 
         // published html page(s)
         HtmlPage page = client.getPage(job, "report-name");
         HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
-        assertEquals("%23%24%26%2B%2C%3A%3B%3D%20%3F%40.html", iframe.getAttribute("src"));
+        assertEquals("%23%24%26%2B%2C%3B%3D%20%3F%40.html", iframe.getAttribute("src"));
 
         HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
         assertEquals("Hello world!", pageInIframe.getBody().asText());

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -1,0 +1,46 @@
+package htmlpublisher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.CreateFileBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.gargoylesoftware.htmlunit.html.HtmlInlineFrame;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import hudson.model.FreeStyleProject;
+
+public class HtmlFileNameTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void fileNameWithSpecialCharacters() throws Exception {
+        final String content = "<html><head><title>test</title></head><body>Hello world!</body></html>";
+
+        FreeStyleProject job = j.createFreeStyleProject();
+
+        job.getBuildersList().add(new CreateFileBuilder("#$&+,:;= ?@.html", content));
+        job.getPublishersList().add(new HtmlPublisher(List.of(
+            new HtmlPublisherTarget("report-name", "", "*.html", true, true, false))));
+        job.save();
+
+        j.buildAndAssertSuccess(job);
+
+        JenkinsRule.WebClient client = j.createWebClient();
+        assertEquals(content,
+            client.getPage(job, "report-name/%23%24%26%2B%2C%3A%3B%3D%20%3F%40.html").getWebResponse().getContentAsString());
+
+        // published html page(s)
+        HtmlPage page = client.getPage(job, "report-name");
+        HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
+        assertEquals("%23%24%26%2B%2C%3A%3B%3D%20%3F%40.html", iframe.getAttribute("src"));
+
+        HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
+        assertEquals("Hello world!", pageInIframe.getBody().asText());
+    }
+}

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -24,7 +24,7 @@ public class HtmlFileNameTest {
 
         FreeStyleProject job = j.createFreeStyleProject();
 
-        job.getBuildersList().add(new CreateFileBuilder("#$&+,;= ?@.html", content));
+        job.getBuildersList().add(new CreateFileBuilder("#$&+,;= @.html", content));
         job.getPublishersList().add(new HtmlPublisher(Arrays.asList(
             new HtmlPublisherTarget("report-name", "", "*.html", true, true, false))));
         job.save();
@@ -33,12 +33,12 @@ public class HtmlFileNameTest {
 
         JenkinsRule.WebClient client = j.createWebClient();
         assertEquals(content,
-            client.getPage(job, "report-name/%23%24%26%2B%2C%3B%3D%20%3F%40.html").getWebResponse().getContentAsString());
+            client.getPage(job, "report-name/%23%24%26%2B%2C%3B%3D%20%40.html").getWebResponse().getContentAsString());
 
         // published html page(s)
         HtmlPage page = client.getPage(job, "report-name");
         HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
-        assertEquals("%23%24%26%2B%2C%3B%3D%20%3F%40.html", iframe.getAttribute("src"));
+        assertEquals("%23%24%26%2B%2C%3B%3D%20%40.html", iframe.getAttribute("src"));
 
         HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
         assertEquals("Hello world!", pageInIframe.getBody().asText());

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -2,7 +2,7 @@ package htmlpublisher;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,7 +25,7 @@ public class HtmlFileNameTest {
         FreeStyleProject job = j.createFreeStyleProject();
 
         job.getBuildersList().add(new CreateFileBuilder("#$&+,:;= ?@.html", content));
-        job.getPublishersList().add(new HtmlPublisher(List.of(
+        job.getPublishersList().add(new HtmlPublisher(Arrays.asList(
             new HtmlPublisherTarget("report-name", "", "*.html", true, true, false))));
         job.save();
 


### PR DESCRIPTION
The file name could contain URL unsafe characters, when used to construct 'src' attribute of the iframe, it must be URL
encoded. 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
