### PR TITLE
Fixed handling of slashes in html filename (JENKINS-66929)

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -81,7 +81,7 @@ function updateBody(tabId, page) {
     tab.setAttribute("class", "selected");
     selectedTab = tabId;
     iframe = document.getElementById("myframe");
-    iframe.src = encodeURIComponent(tab.getAttribute("value"));
+    iframe.src = encodeURIComponent(tab.getAttribute("value")).replace('%2F', '/');
 }
 function init(tabId){
 	updateBody(tabId);

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -24,21 +24,21 @@ public class HtmlFileNameTest {
 
         FreeStyleProject job = j.createFreeStyleProject();
 
-        job.getBuildersList().add(new CreateFileBuilder("#$&+,;= @.html", content));
+        job.getBuildersList().add(new CreateFileBuilder("subdir/#$&+,;= @.html", content));
         job.getPublishersList().add(new HtmlPublisher(Arrays.asList(
-            new HtmlPublisherTarget("report-name", "", "*.html", true, true, false))));
+            new HtmlPublisherTarget("report-name", "", "subdir/*.html", true, true, false))));
         job.save();
 
         j.buildAndAssertSuccess(job);
 
         JenkinsRule.WebClient client = j.createWebClient();
         assertEquals(content,
-            client.getPage(job, "report-name/%23%24%26%2B%2C%3B%3D%20%40.html").getWebResponse().getContentAsString());
+            client.getPage(job, "report-name/subdir/%23%24%26%2B%2C%3B%3D%20%40.html").getWebResponse().getContentAsString());
 
         // published html page(s)
         HtmlPage page = client.getPage(job, "report-name");
         HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
-        assertEquals("%23%24%26%2B%2C%3B%3D%20%40.html", iframe.getAttribute("src"));
+        assertEquals("subdir/%23%24%26%2B%2C%3B%3D%20%40.html", iframe.getAttribute("src"));
 
         HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
         assertEquals("Hello world!", pageInIframe.getBody().asText());


### PR DESCRIPTION
The html filename may contain subdirs with slashes. Since v1.26 the slashes are encoded as %2F.
These slashes should not be html encoded but remain as slashes in the 'src' attribute of the iframe.

This behavior has been introduced with PR https://github.com/jenkinsci/htmlpublisher-plugin/pull/108.

See also [JENKINS-65028](https://issues.jenkins.io/browse/JENKINS-65028) and [JENKINS-66929](https://issues.jenkins.io/browse/JENKINS-66929)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue