### PR TITLE
Bugfix: Replace all occurrences of %2F with slashes in file names

### DIFF
--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -81,7 +81,7 @@ function updateBody(tabId, page) {
     tab.setAttribute("class", "selected");
     selectedTab = tabId;
     iframe = document.getElementById("myframe");
-    iframe.src = encodeURIComponent(tab.getAttribute("value")).replace('%2F', '/');
+    iframe.src = encodeURIComponent(tab.getAttribute("value")).replace(/%2F/g, '/');
 }
 function init(tabId){
 	updateBody(tabId);

--- a/src/test/java/htmlpublisher/HtmlFileNameTest.java
+++ b/src/test/java/htmlpublisher/HtmlFileNameTest.java
@@ -24,21 +24,21 @@ public class HtmlFileNameTest {
 
         FreeStyleProject job = j.createFreeStyleProject();
 
-        job.getBuildersList().add(new CreateFileBuilder("subdir/#$&+,;= @.html", content));
+        job.getBuildersList().add(new CreateFileBuilder("subdir/subdir2/#$&+,;= @.html", content));
         job.getPublishersList().add(new HtmlPublisher(Arrays.asList(
-            new HtmlPublisherTarget("report-name", "", "subdir/*.html", true, true, false))));
+            new HtmlPublisherTarget("report-name", "", "subdir/subdir2/*.html", true, true, false))));
         job.save();
 
         j.buildAndAssertSuccess(job);
 
         JenkinsRule.WebClient client = j.createWebClient();
         assertEquals(content,
-            client.getPage(job, "report-name/subdir/%23%24%26%2B%2C%3B%3D%20%40.html").getWebResponse().getContentAsString());
+            client.getPage(job, "report-name/subdir/subdir2/%23%24%26%2B%2C%3B%3D%20%40.html").getWebResponse().getContentAsString());
 
         // published html page(s)
         HtmlPage page = client.getPage(job, "report-name");
         HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
-        assertEquals("subdir/%23%24%26%2B%2C%3B%3D%20%40.html", iframe.getAttribute("src"));
+        assertEquals("subdir/subdir2/%23%24%26%2B%2C%3B%3D%20%40.html", iframe.getAttribute("src"));
 
         HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
         assertEquals("Hello world!", pageInIframe.getBody().asText());


### PR DESCRIPTION
`replace('%2F', '/')` would only replace the first occurrence of `%2F` with a slash, resulting in broken relative links on pages whose paths contain multiple slashes.

Discussion: https://github.com/jenkinsci/htmlpublisher-plugin/pull/138/commits/5c02afab96343c128ae5df8da4bbe9dbdd3cd616#r746408830