### PR TITLE
fix: fail build when missing not allowed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/htmlpublisher-plugin</gitHubRepo>
     <jenkins.version>2.346.1</jenkins.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <licenses>
@@ -92,6 +94,11 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -388,11 +388,6 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
             return build;
         }
 
-        @Deprecated
-        private final Object getAbstractBuildOwner(Run build, Class targetClass) {
-            return build instanceof AbstractBuild ? (AbstractBuild) build : null;
-        }
-
         @Override
         public void onAttached(Run<?, ?> r) {
             this.build = r;

--- a/src/main/java/htmlpublisher/workflow/PublishHTMLStepExecution.java
+++ b/src/main/java/htmlpublisher/workflow/PublishHTMLStepExecution.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
@@ -44,6 +45,7 @@ import hudson.model.TaskListener;
 public class PublishHTMLStepExecution extends SynchronousNonBlockingStepExecution<Void> {
     private static final long serialVersionUID = 1L;
 
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED")
     private final transient PublishHTMLStep step;
 
     PublishHTMLStepExecution(PublishHTMLStep step, @NonNull StepContext context) {

--- a/src/test/java/htmlpublisher/workflow/PublishHTMLStepTest.java
+++ b/src/test/java/htmlpublisher/workflow/PublishHTMLStepTest.java
@@ -167,6 +167,7 @@ public class PublishHTMLStepTest {
         HtmlPublisherTarget.HTMLBuildAction report = run.getAction(HtmlPublisherTarget.HTMLBuildAction.class);
         assertNull("Report should be missing", report);
         r.assertLogContains("Specified HTML directory '" + missingReportDirFile + "' does not exist.", run);
+        r.assertLogNotContains("STEP_AFTER_PUBLISH_HTML", run);
     }
 
     @Test
@@ -180,6 +181,7 @@ public class PublishHTMLStepTest {
         r.assertBuildStatus(Result.SUCCESS, run);
         HtmlPublisherTarget.HTMLBuildAction report = run.getAction(HtmlPublisherTarget.HTMLBuildAction.class);
         assertNull("Report should be missing", report);
+        r.assertLogContains("STEP_AFTER_PUBLISH_HTML", run);
     }
 
     private void writeTestHTML(String fileName) throws Exception {
@@ -205,7 +207,8 @@ public class PublishHTMLStepTest {
                 + "node('slave') {\n"
                 + "  publishHTML(target: [allowMissing: " + target.getAllowMissing() +
                   ", keepAll: " + target.getKeepAll() + ", reportDir: '" + target.getReportDir() +
-                  "', reportFiles: '" + target.getReportFiles() + "', reportName: '" + target.getReportName() + "']) \n"
+                  "', reportFiles: '" + target.getReportFiles() + "', reportName: '" + target.getReportName() + "']) \n" +
+                  "  echo 'STEP_AFTER_PUBLISH_HTML'"
                 + "}", true));
         QueueTaskFuture<WorkflowRun> runFuture = job.scheduleBuild2(0);
         assertThat("build was actually scheduled", runFuture, Matchers.notNullValue());


### PR DESCRIPTION
If allowMissing is set to false html publisher should cause the step to fail rather than just setting the build status to failed.

Refs: [JENKINS-70149](https://issues.jenkins.io/browse/JENKINS-70149)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
