### PR TITLE
Create bridge methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,4 +122,20 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.infradna.tool</groupId>
+        <artifactId>bridge-method-injector</artifactId>
+        <version>1.29</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Bridge methods were being defined but not actually created because the bridge method injector was not being executed at build time.

### Testing done

Comparing the output of `javap -c './target/classes/htmlpublisher/HtmlPublisherTarget$HTMLPublishedForProjectMarkerAction.class'` before and after this PR:

```
--- /tmp/old    2024-03-11 15:04:01.355304753 -0700
+++ /tmp/new    2024-03-11 15:14:33.404180689 -0700
@@ -37,4 +37,14 @@
        0: aload_0
        1: getfield      #7                  // Field actualHtmlPublisherTarget:Lhtmlpublisher/HtmlPublisherTarget;
        4: areturn
+
+  public final hudson.model.AbstractBuild getOwner();
+    Code:
+       0: aload_0
+       1: aload_0
+       2: invokevirtual #67                 // Method getOwner:()Lhudson/model/Run;
+       5: ldc           #17                 // class hudson/model/AbstractBuild
+       7: invokevirtual #69                 // Method getAbstractBuildOwner:(Lhudson/model/Run;Ljava/lang/Class;)Ljava/lang/Object;
+      10: checkcast     #17                 // class hudson/model/AbstractBuild
+      13: areturn
 }
```