### PR TITLE
Remove unnecessary JARs from JPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,11 +104,15 @@
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-suppressions</artifactId>
       <version>${access-modifier-checker.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>access-modifier-annotation</artifactId>
-      <version>1.33</version>
+      <!-- Not needed at runtime -->
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Upper bounds and comes from core -->
+          <groupId>org.kohsuke</groupId>
+          <artifactId>access-modifier-annotation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
jenkinsci/htmlpublisher-plugin@6b840248dd0d691bbac9b515cd750b3f925909b2 started bundling the following unnecessary JARs into the plugin JPI:

```
[INFO] Bundling direct dependency access-modifier-annotation-1.33.jar
[INFO] Bundling direct dependency access-modifier-suppressions-1.33.jar
```

### Testing done

Verified the JARs are no longer bundled during a plugin build.