### PR TITLE
Make dep on `matrix-project` optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -390,21 +390,26 @@ public class HtmlPublisher extends Recorder {
             List<Action> actions = new ArrayList<>();
             for (HtmlPublisherTarget target : this.reportTargets) {
                 actions.add(target.getProjectAction(project));
-                if (project instanceof MatrixProject && ((MatrixProject) project).getActiveConfigurations() != null){
-                    for (MatrixConfiguration mc : ((MatrixProject) project).getActiveConfigurations()){
-                        try {
-                          mc.onLoad(mc.getParent(), mc.getName());
-                        }
-                        catch (IOException e){
-                            //Could not reload the configuration.
-                        }
-                    }
+                if (project.getClass().getName().equals("hudson.matrix.MatrixProject")) {
+                    adjustMatrixProject(project);
                 }
             }
             return actions;
         }
     }
 
+    private static void adjustMatrixProject(AbstractProject<?, ?> project) {
+        MatrixProject mp = (MatrixProject) project;
+        if (mp.getActiveConfigurations() != null) {
+            for (MatrixConfiguration mc : mp.getActiveConfigurations()) {
+                try {
+                    mc.onLoad(mc.getParent(), mc.getName());
+                } catch (IOException e) {
+                    //Could not reload the configuration.
+                }
+            }
+        }
+    }
 
     @SuppressRestrictedWarnings(NoExternalUse.class)
     public static DirScanner dirScannerGlob(String includes, String excludes, boolean useDefaultExcludes, OpenOption... openOptions) throws Exception {


### PR DESCRIPTION
So that a Jenkins installation which is 100% Pipeline can not bother having this plugin installed. Amends 6204dbf85178ec951af0dfefc088d93fe451ac1e. The purported fix seems very suspect to me (`Item.onLoad` should be called only by Jenkins core, not in this context) and there is no regression test so I am half inclined just to delete it.