### PR TITLE
[JENKINS-74015][JENKINS-74746] Improve CSP compatibility

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -60,6 +60,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.Functions;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.model.AbstractBuild;
@@ -237,6 +238,7 @@ public class HtmlPublisher extends Recorder {
         for (int i=0; i < reportTargets.size(); i++) {
             // Create an array of lines we will eventually write out, initially the header.
             List<String> reportLines = new ArrayList<>(headerLines);
+            reportLines.add("<script type=\"text/javascript\" src=\"" + Jenkins.get().getRootUrl() + Functions.getResourcePath() + "/plugin/htmlpublisher/js/htmlpublisher.js\"></script>");
             HtmlPublisherTarget reportTarget = reportTargets.get(i);
             boolean keepAll = reportTarget.getKeepAll();
             boolean allowMissing = reportTarget.getAllowMissing();
@@ -338,23 +340,14 @@ public class HtmlPublisher extends Recorder {
                 } else {
                     reportFile = report;
                 }
-                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" onclick=\"updateBody('" + tabNo + "');\" value=\"" + htmlAttributeEscape(report) + "\">" + htmlAttributeEscape(getTitle(reportFile, titles, j)) + "</li>";
+                String tabItem = "<li id=\"" + tabNo + "\" class=\"unselected\" value=\"" + htmlAttributeEscape(report) + "\">" + htmlAttributeEscape(getTitle(reportFile, titles, j)) + "</li>";
                 reportLines.add(tabItem);
             }
             // Add the JS to change the link as appropriate.
             String hudsonUrl = Jenkins.get().getRootUrl();
             Job job = build.getParent();
-            reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").innerHTML=\"Back to " + htmlAttributeEscape(job.getName()) + "\";</script>");
-            // If the URL isn't configured in Hudson, the best we can do is attempt to go Back.
-            if (hudsonUrl == null) {
-                reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").onclick = function() { history.go(-1); return false; };</script>");
-            } else {
-                String jobUrl = hudsonUrl + job.getUrl();
-                reportLines.add("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").href=\"" + jobUrl + "\";</script>");
-            }
-
-            reportLines.add("<script type=\"text/javascript\">document.getElementById(\"zip_link\").href=\"*zip*/" + reportTarget.getSanitizedName() + ".zip\";</script>");
-
+            reportLines.add("<span class='links-data-holder' data-back-to-name='" + job.getName() + "' data-root-url='" +
+                    hudsonUrl + "' data-job-url='" + job.getUrl() + "' data-zip-link='" + reportTarget.getSanitizedName() + "'/>");
             // Now add the footer.
             reportLines.addAll(footerLines);
             // And write this as the index

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.DirScanner;
+import io.jenkins.cli.shaded.org.apache.commons.lang.StringUtils;
 import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -238,7 +239,7 @@ public class HtmlPublisher extends Recorder {
         for (int i=0; i < reportTargets.size(); i++) {
             // Create an array of lines we will eventually write out, initially the header.
             List<String> reportLines = new ArrayList<>(headerLines);
-            reportLines.add("<script type=\"text/javascript\" src=\"" + Jenkins.get().getRootUrl() + Functions.getResourcePath() + "/plugin/htmlpublisher/js/htmlpublisher.js\"></script>");
+            reportLines.add("<script type=\"text/javascript\" src=\"" + getStaticResourcesUrl() + "/plugin/htmlpublisher/js/htmlpublisher.js\"></script>");
             HtmlPublisherTarget reportTarget = reportTargets.get(i);
             boolean keepAll = reportTarget.getKeepAll();
             boolean allowMissing = reportTarget.getAllowMissing();
@@ -389,6 +390,15 @@ public class HtmlPublisher extends Recorder {
             }
             return actions;
         }
+    }
+
+    private static String getStaticResourcesUrl() {
+        String rootUrl = Jenkins.get().getRootUrl();
+        if (rootUrl == null) {
+            rootUrl = "";
+        }
+
+        return StringUtils.stripEnd(rootUrl, "/") + Functions.getResourcePath();
     }
 
     private static void adjustMatrixProject(AbstractProject<?, ?> project) {

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -47,8 +47,8 @@ import java.util.List;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.DirScanner;
-import io.jenkins.cli.shaded.org.apache.commons.lang.StringUtils;
 import jenkins.util.SystemProperties;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;

--- a/src/main/resources/htmlpublisher/HtmlPublisher/header.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/header.html
@@ -86,26 +86,9 @@ h2
 }
 
 </style>
-
-<script type="text/javascript">
-function updateBody(tabId, page) {
-    document.getElementById(selectedTab).setAttribute("class", "unselected");
-    tab = document.getElementById(tabId)
-    tab.setAttribute("class", "selected");
-    selectedTab = tabId;
-    iframe = document.getElementById("myframe");
-    iframe.src = encodeURIComponent(tab.getAttribute("value")).replace(/%2F/g, '/');
-}
-function init(tabId){
-	updateBody(tabId);
-}
-
-var selectedTab = "tab1"
-</script>
-
 </head>
 
-<body onload="init('tab1');">
+<body>
 <nav>
 <h1><a id="hudson_link" href="#"></a></h1>
 <h2><a id="zip_link" href="#">Zip</a></h2>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
@@ -5,12 +5,13 @@ import htmlpublisher.HtmlPublisherTarget
 import hudson.Functions
 import hudson.Util
 import hudson.model.Descriptor
-import jenkins.model.Jenkins
 
 import java.security.MessageDigest
 
 l = namespace(lib.LayoutTagLib)
 st = namespace("jelly:stapler")
+
+Functions.initPageVariables(context)
 
 def text = new File(my.dir(), my.getHTMLTarget().getWrapperName()).text
 
@@ -28,7 +29,7 @@ def serveWrapper() {
     def footer = HtmlPublisher.class.getResourceAsStream("/htmlpublisher/HtmlPublisher/footer.html").text
 
     raw(header)
-    script(src: "${Jenkins.get().getRootUrl() + Functions.getResourcePath()}/plugin/htmlpublisher/js/htmlpublisher.js", type: "text/javascript")
+    script(src: "${resURL}/plugin/htmlpublisher/js/htmlpublisher.js", type: "text/javascript")
 
     def legacyFile = new File(my.dir(), "htmlpublisher-wrapper.html")
     def matcher = legacyFile.text =~ /<li id="tab\d+" class="unselected"(?: onclick="updateBody\('tab\d+'\);")? value="([^"]+)">([^<]+)<\/li>/

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
@@ -2,8 +2,10 @@ package htmlpublisher.HtmlPublisherTarget.BaseHTMLAction
 
 import htmlpublisher.HtmlPublisher
 import htmlpublisher.HtmlPublisherTarget
+import hudson.Functions
 import hudson.Util
 import hudson.model.Descriptor
+import jenkins.model.Jenkins
 
 import java.security.MessageDigest
 
@@ -26,9 +28,10 @@ def serveWrapper() {
     def footer = HtmlPublisher.class.getResourceAsStream("/htmlpublisher/HtmlPublisher/footer.html").text
 
     raw(header)
+    script(src: "${Jenkins.get().getRootUrl() + Functions.getResourcePath()}/plugin/htmlpublisher/js/htmlpublisher.js", type: "text/javascript")
 
     def legacyFile = new File(my.dir(), "htmlpublisher-wrapper.html")
-    def matcher = legacyFile.text =~ /<li id="tab\d+" class="unselected" onclick="updateBody\('tab\d+'\);" value="([^"]+)">([^<]+)<\/li>/
+    def matcher = legacyFile.text =~ /<li id="tab\d+" class="unselected"(?: onclick="updateBody\('tab\d+'\);")? value="([^"]+)">([^<]+)<\/li>/
 
     def items = []
     def itemsTitle = []
@@ -39,14 +42,15 @@ def serveWrapper() {
 
     def idx = 1
     items.each { file ->
-        li(itemsTitle[idx - 1], id: "tab${idx}", class: "unselected", onclick: "updateBody('tab${idx}')", value: file.trim())
+        li(itemsTitle[idx - 1], id: "tab${idx}", class: "unselected", value: file.trim())
         idx++
     }
 
-    // TODO replace unnecessary JS usage by properly integrating header.html/footer.html in this groovy view
-    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").innerHTML=\"Back to ${my.backToName}\";</script>")
-    raw("<script type=\"text/javascript\">document.getElementById(\"hudson_link\").href=\"${rootURL}/${my.backToUrl}\";</script>")
-    raw("<script type=\"text/javascript\">document.getElementById(\"zip_link\").href=\"*zip*/${my.getHTMLTarget().sanitizedName}.zip\";</script>")
+    span(class: "links-data-holder", 
+            "data-back-to-name": "${my.backToName}",
+            "data-root-url": "${rootURL}",
+            "data-job-url": "${my.backToUrl}",
+            "data-zip-link": "${my.getHTMLTarget().sanitizedName}")
 
     raw(footer)
 }

--- a/src/main/webapp/js/htmlpublisher.js
+++ b/src/main/webapp/js/htmlpublisher.js
@@ -1,0 +1,31 @@
+function updateBody(tabId) {
+  document.getElementById(selectedTab).setAttribute("class", "unselected");
+  tab = document.getElementById(tabId)
+  tab.setAttribute("class", "selected");
+  selectedTab = tabId;
+  iframe = document.getElementById("myframe");
+  iframe.src = encodeURIComponent(tab.getAttribute("value")).replace(/%2F/g, '/');
+}
+function init(tabId){
+  updateBody(tabId);
+}
+
+var selectedTab = "tab1";
+
+window.addEventListener("DOMContentLoaded", () => {
+  init("tab1");
+  
+  const dataHolder = document.querySelector(".links-data-holder");
+  const { backToName, rootUrl, jobUrl, zipLink } = dataHolder.dataset;
+  const backButton = document.querySelector("#hudson_link");
+  backButton.innerText = `Back to ${backToName}`;
+  backButton.href = `${rootUrl}/${jobUrl}`;
+
+  document.querySelector("#zip_link").href = `*zip*/${zipLink}.zip`;
+  
+  document.querySelectorAll("#tabnav li").forEach((item) => {
+    item.addEventListener("click", (event) => {
+      updateBody(event.target.id);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74015
https://issues.jenkins.io/browse/JENKINS-74746

There are two ways that generated HTML reports are rendered. Which mode is used is controlled by `useWrapperFileDirectly` flag. The HTML report is generated during the build step and is saved in `jobs/JOB_NAME/builds/BUILD_NUMBER/htmlreports` directory. If `useWrapperFileDirectly` flag is set to true then the file generated during the build step will be served directly. If the flag is false then [this code](https://github.com/jenkinsci/htmlpublisher-plugin/blob/9eb828375acb84f4c4a20e9c0ad68a12a49ef094/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy#L30-L38) reads the report file and extracts pieces of data that are inside the `li` tags and then few lines below recreates them (I don't know why, the way reports are generated and served raises many questions).

For both ways the pages that are served to the end used contain the same inline script blocks and inline event handlers. Those were extracted from both places and replaced by the inclusion of a JavaScript file via `script` tag.

### Testing done

Both screen recordings contain commentary, because there's a lot to cover.
[Before the change](https://www.youtube.com/watch?v=EmwABzfCydo)
[After the change](https://www.youtube.com/watch?v=wGYCwTkre2I)

I've tried to cover the cases I had in mind, though I don't think this is exhaustive. If you have scenarios in mind that I haven't covered in the recording please let me know.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
