### PR TITLE
Add support for icon on sidebar report action

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Clicking _Publishing options..._ will present you with some additional options:
 * Allow missing report - if `false`, build will be marked as failed if the report directory does not exist.
 * Include files - Optional Ant pattern that specifies what files in the report directory to archive. Defaults to archiving all files in the given report directory.
 * Escape underscores in Report Title - if `true`, underscores in report titles will be escaped to `_5F` along with other non-alphanumeric characters. If `false` they will be left as is.
+* Icon - Optional icon to use for the report. If not provided, a default icon will be used. The icon can be an existing `symbol` or an icon from the reportDir
 
 #### Using with Pipeline Jobs
 

--- a/src/main/java/htmlpublisher/HtmlPublisherTarget.java
+++ b/src/main/java/htmlpublisher/HtmlPublisherTarget.java
@@ -76,6 +76,11 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
     private final boolean allowMissing;
 
     /**
+     *  The path or symbol of an icon to use for the HTML report in the sidebar (relative to reportDir)
+     */
+    private String icon;
+
+    /**
      * Do not use, but keep to maintain compatibility with older releases. See JENKINS-31366.
      */
     @Deprecated
@@ -160,6 +165,15 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         } else {
             return this.escapeUnderscores;
         }
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    @DataBoundSetter
+    public void setIcon(String icon) {
+        this.icon = StringUtils.trim(icon);
     }
 
     @DataBoundSetter
@@ -266,7 +280,18 @@ public class HtmlPublisherTarget extends AbstractDescribableImpl<HtmlPublisherTa
         }
 
         public String getIconFileName() {
-            return dir().exists() ? "symbol-document-text" : null;
+            String icon;
+            if (StringUtils.isNotBlank(actualHtmlPublisherTarget.icon)) {
+                if (actualHtmlPublisherTarget.icon.startsWith("symbol-")) {
+                    icon = actualHtmlPublisherTarget.icon;
+                }
+                else {
+                    icon = project.getUrl() + dir().getName() + "/" + actualHtmlPublisherTarget.icon;
+                }
+            } else {
+                icon = "symbol-document-text";
+            }
+            return dir().exists() ? icon : null;
         }
 
         public String getBackToName() {

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
@@ -43,5 +43,8 @@
     <f:entry field="numberOfWorkers" title="${%numberOfWorkers.title}">
       <f:number/>
     </f:entry>
+    <f:entry field="icon" title="${%icon.title}">
+      <f:textbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
@@ -10,3 +10,4 @@ allowMissing.title=Allow missing report
 escapeUnderscores.title=Escape underscores in Report Title
 useWrapperFileDirectly.title=Use the legacy wrapper file
 numberOfWorkers.title=Number of workers
+icon.title=Icon

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-icon.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/help-icon.html
@@ -1,0 +1,3 @@
+<div>
+    The path of an icon or symbol to use for the HTML report (relative to reportDir)
+</div>

--- a/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
+++ b/src/test/java/htmlpublisher/HtmlPublisherIntegrationTest.java
@@ -313,6 +313,33 @@ public class HtmlPublisherIntegrationTest {
     }
 
     @Test
+    public void testIcon() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject("variable_job");
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                FilePath ws = build.getWorkspace();
+                ws.child("dirA").child("file1.html").write("hello", "UTF-8");
+                ws.child("dirA").child("file2.html").write("hello", "UTF-8");
+                return true;
+            }
+        });
+        HtmlPublisherTarget target1 = new HtmlPublisherTarget("reportnameB", "dirB", "", true, true, true);
+        target1.setIcon("symbol-cube");
+        HtmlPublisherTarget target2 = new HtmlPublisherTarget("reportnameA", "dirA", "", true, true, false);
+        target2.setIcon("symbol-build");
+
+        List<HtmlPublisherTarget> targets = new ArrayList<>();
+        targets.add(target1);
+        targets.add(target2);
+        p.getPublishersList().add(new HtmlPublisher(targets));
+        AbstractBuild build = j.buildAndAssertSuccess(p);
+        assertTrue("reportnameA/htmlpublisher-wrapper.html must exist", new File(build.getRootDir(), "htmlreports/reportnameA/htmlpublisher-wrapper.html").exists());
+        assertTrue("reportnameA/file1.html must exist", new File(build.getRootDir(), "htmlreports/reportnameA/file1.html").exists());
+        assertTrue("reportnameA/file2.html must exist", new File(build.getRootDir(), "htmlreports/reportnameA/file2.html").exists());
+        assertFalse("reportnameB/htmlpublisher-wrapper.html must not exist", new File(build.getRootDir(), "htmlreports/reportnameB/htmlpublisher-wrapper.html").exists());
+    }
+
+    @Test
     public void testPublishesTwoReportsOneJob() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("variable_job");
         p.getBuildersList().add(new TestBuilder() {


### PR DESCRIPTION
Inspired by https://github.com/jenkinsci/htmlpublisher-plugin/pull/277 (that was most likely abandoned)

And ensure it support custom `symbol`

### Testing done

Interactive tests with freestyle job with both image from report and symbol 

**With symbol**

![Screenshot from 2024-11-30 15-18-05](https://github.com/user-attachments/assets/40983f2c-194f-4f39-8940-23cf3b933c58)
![Screenshot from 2024-11-30 15-18-21](https://github.com/user-attachments/assets/1c041126-36fa-44a8-8826-5eb189fe5119)

**With image from report**

![Screenshot from 2024-11-30 15-31-16](https://github.com/user-attachments/assets/9976acf1-5a57-4c18-8367-72caad393b5c)
![Screenshot from 2024-11-30 15-23-56](https://github.com/user-attachments/assets/8292a2a3-f050-4c5a-becd-ad931c7a0753)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
