### PR TITLE
Remove redundant bridge-method-injector plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.9</version>
+    <version>5.12</version>
     <relativePath />
   </parent>
 
@@ -128,20 +128,4 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.infradna.tool</groupId>
-        <artifactId>bridge-method-injector</artifactId>
-        <version>1.30</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>process</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
### What this PR does?

This PR follows up this [PR ](https://github.com/jenkinsci/plugin-pom/pull/1125)in the plugin-pom repo. 

It removes the declaration of the bridge-method-injector plugin from the build section, as it is now provided by plugin-pom starting from version 5.12.

### Testing done

- Verified the plugin still builds successfully with **mvn clean verify**
- Verified that the bridge-method-injector plugin is inherited, checking the effective pom

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
