### PR TITLE
Allow overriding Content Security Policy on published artefacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
       <version>1.20.6</version>
       <scope>test</scope>
     </dependency>
+	  <dependency>
+		  <groupId>org.assertj</groupId>
+		  <artifactId>assertj-core</artifactId>
+		  <version>3.27.4</version>
+		  <scope>test</scope>
+	  </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-suppressions</artifactId>

--- a/src/main/java/htmlpublisher/ContentSecurity.java
+++ b/src/main/java/htmlpublisher/ContentSecurity.java
@@ -1,0 +1,280 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Michael Clarke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htmlpublisher;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ContentSecurity extends AbstractDescribableImpl<ContentSecurity> {
+
+    private static final Logger LOGGER = Logger.getLogger(ContentSecurity.class.getName());
+
+    private final Scripts scripts;
+    private final Styles styles;
+    private final Images images;
+    private final boolean allowSameOrigin;
+
+    private transient boolean headerWarningLogged = false;
+    private transient boolean iframeWarningLogged = false;
+
+    @DataBoundConstructor
+    public ContentSecurity(Scripts scripts, Styles styles, Images images, boolean allowSameOrigin) {
+        this.scripts = scripts;
+        this.styles = styles;
+        this.images = images;
+        this.allowSameOrigin = allowSameOrigin;
+    }
+
+    public Scripts getScripts() {
+        return scripts;
+    }
+
+    public Styles getStyles() {
+        return styles;
+    }
+
+    public Images getImages() {
+        return images;
+    }
+
+    public boolean isAllowSameOrigin() {
+        return allowSameOrigin;
+    }
+
+    public String createAlteredContentSecurityPolicy(String contentSecurityPolicy) {
+        if (isContentSecurityAlterationDisabled()) {
+            if (areAnyNotNull(scripts, images, styles) || allowSameOrigin) {
+                LOGGER.log(headerWarningLogged ? java.util.logging.Level.FINE : java.util.logging.Level.WARNING,
+                        "Content security policy override has been disabled. Content-Security-Policy header will not be modified.");
+                headerWarningLogged = true;
+            }
+            return contentSecurityPolicy;
+        }
+        if (StringUtils.trimToNull(contentSecurityPolicy) == null) {
+            return null;
+        }
+        Map<String, String> directives = Arrays.stream(contentSecurityPolicy.split(";")).collect(
+                Collectors.toMap(
+                        directive -> directive.trim().split(" ")[0],
+                        directive -> directive,
+                        (directive1, directive2) -> directive1
+                )
+        );
+
+        StringBuilder modifiedCsp = new StringBuilder();
+        modifiedCsp.append(createSandboxContentSecurityDirective(directives.remove("sandbox")));
+        if (scripts != null) {
+            modifiedCsp.append(createScriptsContentSecurityDirective(directives.remove("script-src"), getScripts()));
+        }
+        if (styles != null) {
+            modifiedCsp.append(createStylesContentSecurityDirective(directives.remove("style-src"), getStyles()));
+        }
+        if (images != null) {
+            modifiedCsp.append(createImagesContentSecurityDirective(directives.remove("img-src"), getImages()));
+        }
+
+
+        directives.forEach((k, v) -> modifiedCsp.append(v).append("; "));
+        return modifiedCsp.toString().trim();
+    }
+
+    private static boolean isContentSecurityAlterationDisabled() {
+        return !((HtmlPublisher.DescriptorImpl) Jenkins.get().getDescriptorOrDie(HtmlPublisher.class)).isAllowContentSecurityOverride();
+    }
+
+    private static boolean areAnyNotNull(Object... objects) {
+        for (Object o : objects) {
+            if (Objects.isNull(o)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String createSandboxContentSecurityDirective(String sandboxDirective) {
+        if (sandboxDirective == null) {
+            sandboxDirective = "sandbox ";
+        }
+        if (scripts != null && !sandboxDirective.contains("allow-scripts")) {
+            sandboxDirective = sandboxDirective.trim() + " allow-scripts ";
+        }
+        if (allowSameOrigin && !sandboxDirective.contains("allow-same-origin")) {
+            sandboxDirective = sandboxDirective.trim() + " allow-same-origin ";
+        }
+        return sandboxDirective.trim() + "; ";
+    }
+
+    private static String createScriptsContentSecurityDirective(String scriptSrcDirective, Scripts scripts) {
+        if (scriptSrcDirective == null) {
+            scriptSrcDirective = "script-src 'self'";
+        } else {
+            scriptSrcDirective = scriptSrcDirective.trim();
+        }
+        if (scripts.isAllowUnsafeInline() && !scriptSrcDirective.contains("'unsafe-inline'")) {
+            scriptSrcDirective += " 'unsafe-inline'";
+        }
+        if (scripts.isAllowUnsafeEval() && !scriptSrcDirective.contains("'unsafe-eval'")) {
+            scriptSrcDirective += " 'unsafe-eval'";
+        }
+        return scriptSrcDirective + "; ";
+    }
+
+    private static String createStylesContentSecurityDirective(String styleSrcDirective, Styles styles) {
+        if (styleSrcDirective == null) {
+            styleSrcDirective = "style-src 'self'";
+        } else {
+            styleSrcDirective = styleSrcDirective.trim();
+        }
+        if (styles.isAllowUnsafeInline() && !styleSrcDirective.contains("'unsafe-inline'")) {
+            styleSrcDirective += " 'unsafe-inline'";
+        }
+        return styleSrcDirective + "; ";
+    }
+
+    private static String createImagesContentSecurityDirective(String imageSrcDirective, Images images) {
+        if (imageSrcDirective == null) {
+            imageSrcDirective = "img-src 'self'";
+        } else {
+            imageSrcDirective = imageSrcDirective.trim();
+        }
+        if (images.isAllowData() && !imageSrcDirective.contains("data:")) {
+            imageSrcDirective += " data:";
+        }
+        return imageSrcDirective + "; ";
+    }
+
+    public String createIframeSandboxAttributes() {
+        if (isContentSecurityAlterationDisabled()) {
+            if (areAnyNotNull(scripts, images, styles) || allowSameOrigin) {
+                LOGGER.log(iframeWarningLogged ? java.util.logging.Level.FINE : java.util.logging.Level.WARNING,
+                        "Content security policy override has been disabled. Iframe sandbox will not be modified.");
+                iframeWarningLogged = true;
+            }
+            return "";
+        }
+        String sandbox = "";
+        if (getScripts() != null) {
+            sandbox += " allow-scripts";
+        }
+        if (isAllowSameOrigin()) {
+            sandbox += " allow-same-origin";
+        }
+        return sandbox.trim();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ContentSecurity> {
+
+        @Override
+        public String getDisplayName() {
+            return "Content Security Policy";
+        }
+
+    }
+
+    public static class Scripts extends AbstractDescribableImpl<Scripts> {
+
+        private final boolean allowUnsafeInline;
+        private final boolean allowUnsafeEval;
+
+        @DataBoundConstructor
+        public Scripts(boolean allowUnsafeInline, boolean allowUnsafeEval) {
+            this.allowUnsafeInline = allowUnsafeInline;
+            this.allowUnsafeEval = allowUnsafeEval;
+        }
+
+        public boolean isAllowUnsafeInline() {
+            return allowUnsafeInline;
+        }
+
+        public boolean isAllowUnsafeEval() {
+            return allowUnsafeEval;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<Scripts> {
+            @Override
+            public String getDisplayName() {
+                return "Scripts";
+            }
+        }
+
+    }
+
+    public static class Styles extends AbstractDescribableImpl<Styles> {
+
+        private final boolean allowUnsafeInline;
+
+        @DataBoundConstructor
+        public Styles(boolean allowUnsafeInline) {
+            this.allowUnsafeInline = allowUnsafeInline;
+        }
+
+        public boolean isAllowUnsafeInline() {
+            return allowUnsafeInline;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<Styles> {
+            @Override
+            public String getDisplayName() {
+                return "Styles";
+            }
+        }
+
+    }
+
+    public static class Images extends AbstractDescribableImpl<Images> {
+
+        private final boolean allowData;
+
+        @DataBoundConstructor
+        public Images(boolean allowData) {
+            this.allowData = allowData;
+        }
+
+        public boolean isAllowData() {
+            return allowData;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<Images> {
+            @Override
+            public String getDisplayName() {
+                return "Images";
+            }
+        }
+
+    }
+}

--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -47,6 +47,7 @@ import java.util.List;
 
 import hudson.util.DirScanner;
 import jenkins.util.SystemProperties;
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -84,6 +85,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import htmlpublisher.util.MultithreadedFileCopyHelper;
 import jenkins.util.Timer;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import static hudson.Functions.htmlAttributeEscape;
 
@@ -418,6 +420,9 @@ public class HtmlPublisher extends Recorder {
 
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        private boolean allowContentSecurityOverride;
+
         @Override
         @NonNull
         public String getDisplayName() {
@@ -436,6 +441,16 @@ public class HtmlPublisher extends Recorder {
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
+        }
+
+        @Override
+        public boolean configure(final StaplerRequest2 req, final JSONObject o) {
+            this.allowContentSecurityOverride = o.getBoolean("allowContentSecurityOverride");
+            return true;
+        }
+
+        public boolean isAllowContentSecurityOverride() {
+            return allowContentSecurityOverride;
         }
     }
 

--- a/src/main/resources/htmlpublisher/ContentSecurity/Images/config.jelly
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Images/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry field="allowData" title="${%allowData}">
+		<f:checkbox />
+	</f:entry>
+</j:jelly>
+

--- a/src/main/resources/htmlpublisher/ContentSecurity/Images/config.properties
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Images/config.properties
@@ -1,0 +1,1 @@
+allowData=Enable Data

--- a/src/main/resources/htmlpublisher/ContentSecurity/Images/help-allowData.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Images/help-allowData.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, images defined as in-line data elements (e.g. Base64 encoded PNGs)
+    will be permitted to be loaded and rendered from the page source.
+    <b>Only enable this option if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/Scripts/config.jelly
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Scripts/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="allowUnsafeInline" title="${%allowUnsafeInline}">
+      <f:checkbox />
+    </f:entry>
+    <f:entry field="allowUnsafeEval" title="${%allowUnsafeEval}">
+      <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/htmlpublisher/ContentSecurity/Scripts/config.properties
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Scripts/config.properties
@@ -1,0 +1,2 @@
+allowUnsafeInline=Enable Unsafe Inline
+allowUnsafeEval=Enable Unsafe Eval

--- a/src/main/resources/htmlpublisher/ContentSecurity/Scripts/help-allowUnsafeEval.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Scripts/help-allowUnsafeEval.html
@@ -1,0 +1,6 @@
+<div>
+    If checked, scripts will be permitted to use <code>eval()</code> and similar methods
+    for dynamic code generation. This could make Jenkins vulnerable to cross-site scripting
+    (XSS) attacks if the HTML content is not from a trusted source. <b>Only enable this option
+    if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/Scripts/help-allowUnsafeInline.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Scripts/help-allowUnsafeInline.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, scripts defined inside HTML files will be allowed to run and may be able
+    to access sensitive Jenkins data. <b>Only enable this option if you trust the source
+    of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/Styles/config.jelly
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Styles/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry field="allowUnsafeInline" title="${%allowUnsafeInline}">
+		<f:checkbox />
+	</f:entry>
+</j:jelly>
+

--- a/src/main/resources/htmlpublisher/ContentSecurity/Styles/config.properties
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Styles/config.properties
@@ -1,0 +1,1 @@
+allowUnsafeInline=Enable Unsafe Inline

--- a/src/main/resources/htmlpublisher/ContentSecurity/Styles/help-allowUnsafeInline.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/Styles/help-allowUnsafeInline.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, styles defined directly inside HTML files will be allowed to be applied
+    and could allow the page content to be altered by malicious styles.
+    <b>Only enable this option if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/config.jelly
+++ b/src/main/resources/htmlpublisher/ContentSecurity/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:optionalProperty field="styles" title="${%styles}" />
+	<f:optionalProperty field="scripts" title="${%scripts}" />
+	<f:optionalProperty field="images" title="${%images}" />
+	<f:entry field="allowSameOrigin" title="${%allowSameOrigin}">
+		<f:checkbox />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/htmlpublisher/ContentSecurity/config.properties
+++ b/src/main/resources/htmlpublisher/ContentSecurity/config.properties
@@ -1,0 +1,4 @@
+styles=Styles
+scripts=Scripts
+images=Images
+allowSameOrigin=Enable Same-Origin

--- a/src/main/resources/htmlpublisher/ContentSecurity/help-allowSameOrigin.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/help-allowSameOrigin.html
@@ -1,0 +1,8 @@
+<div>
+    If checked, scripts inside the archive iframe are allowed access to cookies, local
+    storage, and to communicate with the parent iframe's page. This could allow a
+    malicious archived page to attempt to break out the iframe and perform malicious
+    alterations to Jenkins, or steal or alter any Jenkins information persisted in your
+    browser storage. <b>Only enable this option if you trust the source of the HTML
+    files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/help-images.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/help-images.html
@@ -1,0 +1,6 @@
+<div>
+    If checked, Images inside the iframe will be allowed to load and render. This may
+    allow  a malicious page to show or hide content to trick the user into performing
+    actions they did not intend.
+    <b>Only enable this option if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/help-scripts.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/help-scripts.html
@@ -1,0 +1,7 @@
+<div>
+    If checked, Scripts inside the iframe will be allowed to execute.<br /><br />
+    If <i>Enable Same-Origin</i> is also enabled, this may allow any malicious scripts to
+    break out the iframe and perform malicious alterations to Jenkins, or steal or alter
+    any Jenkins information.
+    <b>Only enable this option if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/ContentSecurity/help-styles.html
+++ b/src/main/resources/htmlpublisher/ContentSecurity/help-styles.html
@@ -1,0 +1,6 @@
+<div>
+    If checked, Styles inside the iframe will be allowed to load and render. This may
+    allow  a malicious page to show or hide content to trick the user into performing
+    actions they did not intend.
+    <b>Only enable this option if you trust the source of the HTML files.</b>
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisher/footer.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/footer.html
@@ -1,7 +1,7 @@
 </ul>
 </nav>
 
-<iframe id="myframe"></iframe>
+<iframe id="myframe" sandbox="%s"></iframe>
 
 </body>
 </html>

--- a/src/main/resources/htmlpublisher/HtmlPublisher/global.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/global.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+	<f:section title="${%HTML Publisher}">
+		<f:entry field="allowContentSecurityOverride" title="${%allowContentSecurityOverride}">
+			<f:checkbox />
+		</f:entry>
+	</f:section>
+</j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisher/global.properties
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/global.properties
@@ -1,0 +1,1 @@
+allowContentSecurityOverride=Allow Content Security Policy overrides in jobs

--- a/src/main/resources/htmlpublisher/HtmlPublisher/help-allowContentSecurityOverride.html
+++ b/src/main/resources/htmlpublisher/HtmlPublisher/help-allowContentSecurityOverride.html
@@ -1,0 +1,12 @@
+<div>
+    If checked, will allow users with permissions to configure jobs to server archived
+    artifacts with a less restrictive Content Security Policy then is configured for the
+    rest of the Jenkins instance.
+    <br /><br />
+    This could allow a malicious user with access to configure a job to serve pages with
+    Cross-Site Scripting (XSS) exploits that could be used to attack other Jenkins users
+    or attempt to steal Administrator  credentials.
+    <br /><br />
+    <b>Only enable this option if archived HTML pages are not rendering properly, and
+    users with permission to configure jobs are trusted.</b>
+</div>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/BaseHTMLAction/index.groovy
@@ -53,7 +53,7 @@ def serveWrapper() {
             "data-job-url": "${my.backToUrl}",
             "data-zip-link": "${my.getHTMLTarget().sanitizedName}")
 
-    raw(footer)
+    raw(String.format(footer, my.getIframeSandboxAttributes()))
 }
 
 def serveWrapperLegacyDirectly() {

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.jelly
@@ -46,5 +46,12 @@
     <f:entry field="icon" title="${%icon.title}">
       <f:textbox />
     </f:entry>
+    <f:entry field="contentSecurity" title="${%contentSecurity.title}">
+        <j:if test="${!descriptor.isAllowContentSecurityOverride()}">
+          <p>${%contentSecurityDisabled}</p>
+          <j:set var="readOnlyMode" value="true" />
+        </j:if>
+      <f:property field="contentSecurity"  />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
+++ b/src/main/resources/htmlpublisher/HtmlPublisherTarget/config.properties
@@ -11,3 +11,5 @@ escapeUnderscores.title=Escape underscores in Report Title
 useWrapperFileDirectly.title=Use the legacy wrapper file
 numberOfWorkers.title=Number of workers
 icon.title=Icon
+contentSecurity.title=Content Security Policy and Sandboxing
+contentSecurityDisabled=Content security policy override is not currently enabled on this Jenkins instance. The following settings will be ignored during job execution and cannot be edited until enabled by an Administrator

--- a/src/test/java/htmlpublisher/ContentSecurityIntegrationTest.java
+++ b/src/test/java/htmlpublisher/ContentSecurityIntegrationTest.java
@@ -1,0 +1,62 @@
+package htmlpublisher;
+
+import java.util.List;
+
+import htmlpublisher.ContentSecurity.Scripts;
+import hudson.model.FreeStyleProject;
+import net.sf.json.JSONObject;
+import org.htmlunit.html.HtmlInlineFrame;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.CreateFileBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.StaplerRequest2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithJenkins
+class ContentSecurityIntegrationTest {
+
+    @Test
+    void shouldExecuteJavascriptInPermittedFiles(JenkinsRule jenkinsRule) throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("allowContentSecurityOverride", true);
+        jenkinsRule.jenkins.getDescriptorOrDie(HtmlPublisher.class).configure((StaplerRequest2) null, jsonObject);
+
+        final String content = """
+                    <html>
+                        <head>
+                            <title>test</title>
+                        </head>
+                        <body onload="document.getElementsByTagName('body')[0].innerHTML='Hello Jenkins!'">
+                            Hello world!
+                        </body>
+                    </html>
+                """;
+
+        FreeStyleProject job = jenkinsRule.createFreeStyleProject();
+
+        job.getBuildersList().add(new CreateFileBuilder("subdir/index.html", content));
+        HtmlPublisherTarget target = new HtmlPublisherTarget("report-name", "", "subdir/*.html", true, true, false);
+        target.setContentSecurity(new ContentSecurity(new Scripts(true, true), null, null, false));
+        HtmlPublisher htmlPublisher = new HtmlPublisher(List.of(target));
+        job.getPublishersList().add(htmlPublisher);
+        job.save();
+
+        jenkinsRule.buildAndAssertSuccess(job);
+
+        JenkinsRule.WebClient client = jenkinsRule.createWebClient();
+        assertThat(client.getPage(job, "report-name/subdir/index.html").getWebResponse().getContentAsString()).isEqualTo(content);
+        assertThat(client.getPage(job, "report-name/subdir/index.html").getWebResponse().getResponseHeaderValue("Content-Security-Policy")).isEqualTo("sandbox allow-same-origin allow-scripts; script-src 'self' 'unsafe-inline' 'unsafe-eval';  style-src 'self';  img-src 'self';  default-src 'none';");
+
+        HtmlPage page = client.getPage(job, "report-name");
+
+        HtmlInlineFrame iframe = (HtmlInlineFrame) page.getElementById("myframe");
+        assertThat(iframe.getAttribute("src")).isEqualTo("subdir/index.html");
+        assertThat(iframe.getAttribute("sandbox")).isEqualTo("allow-scripts");
+
+        HtmlPage pageInIframe = (HtmlPage) iframe.getEnclosedPage();
+        assertThat(pageInIframe.getBody().asNormalizedText()).isEqualTo("Hello Jenkins!");
+    }
+}

--- a/src/test/java/htmlpublisher/ContentSecurityTest.java
+++ b/src/test/java/htmlpublisher/ContentSecurityTest.java
@@ -1,0 +1,179 @@
+package htmlpublisher;
+
+import htmlpublisher.ContentSecurity.Images;
+import htmlpublisher.ContentSecurity.Scripts;
+import htmlpublisher.ContentSecurity.Styles;
+import hudson.model.Descriptor.FormException;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.StaplerRequest2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithJenkins
+class ContentSecurityTest {
+
+    private JenkinsRule jenkinsRule;
+
+    @BeforeEach
+    void setUp(JenkinsRule jenkinsRule) throws FormException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("allowContentSecurityOverride", true);
+        jenkinsRule.jenkins.getDescriptorOrDie(HtmlPublisher.class).configure((StaplerRequest2) null, jsonObject);
+        this.jenkinsRule = jenkinsRule;
+    }
+
+    @Nested
+    class IframeSandbox {
+        @ParameterizedTest
+        @CsvSource({
+                "true, true, allow-scripts allow-same-origin",
+                "true, false, allow-scripts",
+                "false, true, allow-same-origin",
+                "false, false, ''"
+        })
+        void shouldCreateIframeSandboxDirective(boolean allowScripts, boolean allowSameOrigin, String expected) {
+            ContentSecurity underTest = new ContentSecurity(allowScripts ? new Scripts(false, false) : null, null, null, allowSameOrigin);
+            String result = underTest.createIframeSandboxAttributes();
+            assertThat(result).isEqualTo(expected);
+        }
+
+        @Test
+        void shouldCreateEmptySandboxDirectiveWhenGlobalOverrideIsDisabled() throws FormException {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("allowContentSecurityOverride", false);
+            jenkinsRule.jenkins.getDescriptorOrDie(HtmlPublisher.class).configure((StaplerRequest2) null, jsonObject);
+
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), null, null, true);
+            String result = underTest.createIframeSandboxAttributes();
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class NoExistingPolicy {
+
+        @Test
+        void shouldCreateDefaultPolicyWhenEmptyPolicyIsSet() {
+            ContentSecurity underTest = new ContentSecurity(null, null, null, false);
+            String result = underTest.createAlteredContentSecurityPolicy("");
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    class SandboxOnlyPolicy {
+
+        @Test
+        void shouldPreserveSandboxWhenOnlySandboxIsSet() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), new Styles(false), null, false);
+            String policy = "sandbox allow-scripts";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox allow-scripts; script-src 'self'; style-src 'self';");
+        }
+
+        @Test
+        void shouldPreserveSandboxWhenGlobalOverrideIsDisabled() throws FormException {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("allowContentSecurityOverride", false);
+            jenkinsRule.jenkins.getDescriptorOrDie(HtmlPublisher.class).configure((StaplerRequest2) null, jsonObject);
+
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), new Styles(false), null, true);
+            String policy = "sandbox allow-scripts";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox allow-scripts");
+        }
+    }
+
+    @Nested
+    class InvalidPolicy {
+
+        @Test
+        void shouldReturnDefaultPolicyWhenPolicyIsInvalid() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), new Styles(false), null, false);
+            String policy = "invalid-policy";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox allow-scripts; script-src 'self'; style-src 'self'; invalid-policy;");
+        }
+    }
+
+    @Nested
+    class ScriptsPresent {
+
+        @Test
+        void shouldCreatePolicyThatAllowsInlineScriptWhenScriptsAreEnabledWithUnsafeInline() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(true, false), new Styles(false), null, true);
+            String policy = "sandbox test-policy";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox test-policy allow-scripts allow-same-origin; script-src 'self' 'unsafe-inline'; style-src 'self';");
+        }
+
+        @Test
+        void shouldCreatePolicyThatAllowsInlineScriptWhenScriptsAreEnabledWithUnsafeEval() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, true), null, null, false);
+            String policy = "sandbox;";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox allow-scripts; script-src 'self' 'unsafe-eval';");
+        }
+
+        @Test
+        void shouldNotAllowInlineScriptWhenScriptsAreEnabledWithoutUnsafeInlineBeingSet() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), new Styles(false), null, false);
+            String policy = "sandbox unknown-directive; script-src 'self'";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox unknown-directive allow-scripts; script-src 'self'; style-src 'self';");
+        }
+
+        @Test
+        void shouldNotAlterPolicyIfScriptsAreAllowedAndSandboxAlreadyAllowsScripts() {
+            ContentSecurity underTest = new ContentSecurity(new Scripts(false, false), null, null, false);
+            String policy = "sandbox allow-scripts;";
+            String result = underTest.createAlteredContentSecurityPolicy(policy);
+            assertThat(result).isEqualTo("sandbox allow-scripts; script-src 'self';");
+        }
+    }
+
+    @Nested
+    class StylesPresent {
+
+        @ParameterizedTest
+        @CsvSource({
+                "true, true, sandbox test-policy, sandbox test-policy; style-src 'self' 'unsafe-inline';",
+                "false, false, sandbox test-policy, sandbox test-policy;",
+                "true, false, sandbox test-policy, sandbox test-policy; style-src 'self';",
+                "true, false, sandbox allow-same-origin; style-src 'self', sandbox allow-same-origin; style-src 'self';"
+        })
+        void shouldCreatePolicyThatMatchesStyleConfiguration(boolean allowStyles, boolean allowUnsafeInline,String contentSecurityPolicy, String expected) {
+            ContentSecurity underTest = new ContentSecurity(null, allowStyles ? new Styles(allowUnsafeInline) : null, null, false);
+            String result = underTest.createAlteredContentSecurityPolicy(contentSecurityPolicy);
+            assertThat(result).isEqualTo(expected);
+        }
+
+    }
+
+
+    @Nested
+    class ImagesPresent {
+
+        @ParameterizedTest
+        @CsvSource({
+                "true, true, sandbox test-policy, sandbox test-policy; img-src 'self' data:;",
+                "false, false, sandbox test-policy, sandbox test-policy;",
+                "true, false, sandbox test-policy, sandbox test-policy; img-src 'self';",
+                "true, false, sandbox allow-same-origin; img-src 'self', sandbox allow-same-origin; img-src 'self';"
+        })
+        void shouldCreatePolicyThatMatchesStyleConfiguration(boolean allowImages, boolean allowData, String contentSecurityPolicy, String expected) {
+            ContentSecurity underTest = new ContentSecurity(null, null, allowImages ? new Images(allowData) : null, false);
+            String result = underTest.createAlteredContentSecurityPolicy(contentSecurityPolicy);
+            assertThat(result).isEqualTo(expected);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Jenkins currently enforces a global Content Security Policy that prevents in-line styles and scripts from being loaded, so prevents archived HTML from tools that use such in-line elements from rendering properly. The workaround for this is to weaken the global policy by allowing such in-line elements to be loaded across Jenkins, although in some places people are recommending to disable CSP completely. To overcome this, the plugin is being altered to allow configuration to be set that enables scripts and styles, and dynamically injects these into the Content-Security-Policy header when serving archived artefacts.

[JENKINS-75843](https://issues.jenkins.io/browse/JENKINS-75843), [JENKINS-75769](https://issues.jenkins.io/browse/JENKINS-75769)

### Testing done

Automated test that shows sandbox attribute being altered on iframe, and Content-Security-Policy header being modified on serving of archived content. Manual testing shows a page that didn't render properly with current plugin now rendering properly with altered plugin:

Gatling report with default htmlpublisher configuration (scripts and styles fail to load):
<img width="1502" height="857" alt="image" src="https://github.com/user-attachments/assets/213ba510-beff-4ba1-a75d-9734a01d1c15" />

<img width="1502" height="329" alt="image" src="https://github.com/user-attachments/assets/c4ab0cad-346a-4a2e-88b2-9e9e73fe798a" />



Gatling report with altered htmlpublisher configuration (scripts and styles successfully load):
<img width="448" height="306" alt="image" src="https://github.com/user-attachments/assets/d5f4ca66-afc2-4b10-9f0c-fb05e7e7f3fc" />

<img width="1506" height="860" alt="image" src="https://github.com/user-attachments/assets/aedf3f8f-48e7-46b7-af39-c4f53484ec84" />

Similarly, ZAP report with default configuration (inline styles and images failing to load):
```
publishHTML([reportDir: 'zap-reports', reportFiles: 'zap_report.html', reportName: 'Zap Report', keepAll: true, allowMissing: true, alwaysLinkToLastBuild: true])
```
<img width="1506" height="851" alt="image" src="https://github.com/user-attachments/assets/dd9b1869-98cb-4483-a499-e68eac030a7c" />
<img width="1511" height="130" alt="image" src="https://github.com/user-attachments/assets/06174d1f-c281-4d44-a02f-cd1ac682c589" />


Same report with styles and images enabled:
```
publishHTML([reportDir: 'zap-reports', reportFiles: 'zap_report.html', reportName: 'Zap Report', keepAll: true, allowMissing: true, alwaysLinkToLastBuild: true, contentSecurity: [styles: [allowUnsafeInline: true], images: [allowData: true]]])
```

<img width="1510" height="856" alt="image" src="https://github.com/user-attachments/assets/f8f7d9ba-ecca-415b-9fb5-5d92241b669c" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
