### PR TITLE
Reduce log severity for missing directories when allowMissing is set

### DIFF
--- a/src/main/java/htmlpublisher/HtmlPublisher.java
+++ b/src/main/java/htmlpublisher/HtmlPublisher.java
@@ -249,11 +249,13 @@ public class HtmlPublisher extends Recorder {
 
             try {
                 if (!archiveDir.exists()) {
-                    listener.error("Specified HTML directory '" + archiveDir + "' does not exist.");
                     if (!allowMissing) {
+                        listener.error("Specified HTML directory '" + archiveDir + "' does not exist.");
                         build.setResult(Result.FAILURE);
                         return true;
                     }
+
+                    logger.println("[htmlpublisher] Specified HTML directory '" + archiveDir + "' does not exist.");
                 }
 
                 if (!keepAll) {


### PR DESCRIPTION
When publishing an HTML report and the directory is missing but the report options have allowMissing set, the output to the user in the build log written as an error.

This change only outputs an error message when allowMissing is not set; otherwise, a more informational message will be displayed.

### Testing done

Run a simple freestyle job with two missing reports configured: one that is allowed missing, and the other that doesn't allow for missing reports and read the job output.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

